### PR TITLE
Polish packet views and add payload tooling

### DIFF
--- a/AXTerm/AX25FrameType.swift
+++ b/AXTerm/AX25FrameType.swift
@@ -18,4 +18,14 @@ enum FrameType: String, Hashable, Codable, CaseIterable {
     var displayName: String {
         rawValue
     }
+
+    var icon: String {
+        switch self {
+        case .ui: return "📡"
+        case .i: return "💬"
+        case .s: return "🔁"
+        case .u: return "⚙️"
+        case .unknown: return "❓"
+        }
+    }
 }

--- a/AXTerm/AXTermApp.swift
+++ b/AXTerm/AXTermApp.swift
@@ -20,6 +20,7 @@ struct AXTermApp: App {
                 }
                 .keyboardShortcut("w", modifiers: [.command])
             }
+            AXTermCommands()
         }
     }
 }

--- a/AXTerm/AXTermCommands.swift
+++ b/AXTerm/AXTermCommands.swift
@@ -1,0 +1,109 @@
+//
+//  AXTermCommands.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 1/28/26.
+//
+
+import SwiftUI
+
+struct SearchFocusAction {
+    let action: () -> Void
+}
+
+struct ToggleConnectionAction {
+    let action: () -> Void
+}
+
+struct InspectPacketAction {
+    let action: () -> Void
+}
+
+struct SelectNavigationAction {
+    let action: (NavigationItem) -> Void
+}
+
+extension FocusedValues {
+    var searchFocus: SearchFocusAction? {
+        get { self[SearchFocusActionKey.self] }
+        set { self[SearchFocusActionKey.self] = newValue }
+    }
+
+    var toggleConnection: ToggleConnectionAction? {
+        get { self[ToggleConnectionActionKey.self] }
+        set { self[ToggleConnectionActionKey.self] = newValue }
+    }
+
+    var inspectPacket: InspectPacketAction? {
+        get { self[InspectPacketActionKey.self] }
+        set { self[InspectPacketActionKey.self] = newValue }
+    }
+
+    var selectNavigation: SelectNavigationAction? {
+        get { self[SelectNavigationActionKey.self] }
+        set { self[SelectNavigationActionKey.self] = newValue }
+    }
+}
+
+private struct SearchFocusActionKey: FocusedValueKey {
+    static let defaultValue: SearchFocusAction? = nil
+}
+
+private struct ToggleConnectionActionKey: FocusedValueKey {
+    static let defaultValue: ToggleConnectionAction? = nil
+}
+
+private struct InspectPacketActionKey: FocusedValueKey {
+    static let defaultValue: InspectPacketAction? = nil
+}
+
+private struct SelectNavigationActionKey: FocusedValueKey {
+    static let defaultValue: SelectNavigationAction? = nil
+}
+
+struct AXTermCommands: Commands {
+    @FocusedValue(\.searchFocus) private var searchFocus
+    @FocusedValue(\.toggleConnection) private var toggleConnection
+    @FocusedValue(\.inspectPacket) private var inspectPacket
+    @FocusedValue(\.selectNavigation) private var selectNavigation
+
+    var body: some Commands {
+        CommandGroup(after: .find) {
+            Button("Focus Search") {
+                searchFocus?.action()
+            }
+            .keyboardShortcut("f", modifiers: [.command])
+        }
+
+        CommandMenu("Connection") {
+            Button("Connect/Disconnect") {
+                toggleConnection?.action()
+            }
+            .keyboardShortcut("k", modifiers: [.command])
+        }
+
+        CommandMenu("View") {
+            Button("Packets") {
+                selectNavigation?.action(.packets)
+            }
+            .keyboardShortcut("1", modifiers: [.command])
+
+            Button("Console") {
+                selectNavigation?.action(.console)
+            }
+            .keyboardShortcut("2", modifiers: [.command])
+
+            Button("Raw") {
+                selectNavigation?.action(.raw)
+            }
+            .keyboardShortcut("3", modifiers: [.command])
+        }
+
+        CommandGroup(after: .textEditing) {
+            Button("Inspect Packet") {
+                inspectPacket?.action()
+            }
+            .keyboardShortcut("i", modifiers: [.command])
+        }
+    }
+}

--- a/AXTerm/CappedArray.swift
+++ b/AXTerm/CappedArray.swift
@@ -1,0 +1,16 @@
+//
+//  CappedArray.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 1/28/26.
+//
+
+import Foundation
+
+enum CappedArray {
+    static func append<Element>(_ element: Element, to array: inout [Element], max: Int) {
+        array.append(element)
+        guard array.count > max else { return }
+        array.removeFirst(array.count - max)
+    }
+}

--- a/AXTerm/ConsoleView.swift
+++ b/AXTerm/ConsoleView.swift
@@ -1,0 +1,113 @@
+//
+//  ConsoleView.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 1/28/26.
+//
+
+import SwiftUI
+
+struct ConsoleView: View {
+    let lines: [ConsoleLine]
+    let onClear: () -> Void
+
+    @State private var autoScroll = true
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Toggle("Auto-scroll", isOn: $autoScroll)
+                    .toggleStyle(.checkbox)
+
+                Spacer()
+
+                Text("\(lines.count) lines")
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+
+                Button("Clear") {
+                    onClear()
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+            .background(.bar)
+
+            Divider()
+
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 4) {
+                        ForEach(lines) { line in
+                            ConsoleLineView(line: line)
+                                .id(line.id)
+                        }
+                    }
+                    .padding()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .onChange(of: lines.count) { _, _ in
+                    if autoScroll, let lastLine = lines.last {
+                        withAnimation(.easeOut(duration: 0.1)) {
+                            proxy.scrollTo(lastLine.id, anchor: .bottom)
+                        }
+                    }
+                }
+            }
+            .background(.background)
+        }
+    }
+}
+
+struct ConsoleLineView: View {
+    let line: ConsoleLine
+    private let callsignSaturation: Double = 0.35
+    private let callsignBrightness: Double = 0.75
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Text(line.timestampString)
+                .foregroundStyle(.secondary)
+
+            if let from = line.from {
+                Text(from)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(callsignColor(for: from))
+
+                if let to = line.to {
+                    Text("→")
+                        .foregroundStyle(.secondary)
+
+                    Text(to)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(callsignColor(for: to))
+                }
+
+                Text(":")
+                    .foregroundStyle(.secondary)
+            }
+
+            Text(line.text)
+                .foregroundStyle(messageColor)
+                .textSelection(.enabled)
+        }
+        .font(.system(.body, design: .monospaced))
+    }
+
+    private var messageColor: Color {
+        switch line.kind {
+        case .system: return .secondary
+        case .error: return .red
+        case .packet: return .primary
+        }
+    }
+
+    private func callsignColor(for callsign: String) -> Color {
+        guard line.kind == .packet else { return messageColor }
+        let hash = abs(callsign.hashValue)
+        let hue = Double(hash % 256) / 255.0
+        return Color(hue: hue, saturation: callsignSaturation, brightness: callsignBrightness)
+    }
+}

--- a/AXTerm/PacketFilter.swift
+++ b/AXTerm/PacketFilter.swift
@@ -1,0 +1,40 @@
+//
+//  PacketFilter.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 1/28/26.
+//
+
+import Foundation
+
+enum PacketFilter {
+    static func filter(
+        packets: [Packet],
+        search: String,
+        filters: PacketFilters,
+        stationCall: String?
+    ) -> [Packet] {
+        packets.filter { packet in
+            if let call = stationCall {
+                guard packet.fromDisplay == call else { return false }
+            }
+
+            guard filters.allows(frameType: packet.frameType) else { return false }
+
+            if filters.onlyWithInfo && packet.infoText == nil {
+                return false
+            }
+
+            if !search.isEmpty {
+                let searchLower = search.lowercased()
+                let matches = packet.fromDisplay.lowercased().contains(searchLower) ||
+                              packet.toDisplay.lowercased().contains(searchLower) ||
+                              packet.viaDisplay.lowercased().contains(searchLower) ||
+                              (packet.infoText?.lowercased().contains(searchLower) ?? false)
+                guard matches else { return false }
+            }
+
+            return true
+        }
+    }
+}

--- a/AXTerm/PacketTableView.swift
+++ b/AXTerm/PacketTableView.swift
@@ -1,0 +1,68 @@
+//
+//  PacketTableView.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 1/28/26.
+//
+
+import SwiftUI
+
+struct PacketTableView: View {
+    let packets: [Packet]
+    @Binding var selection: Set<Packet.ID>
+
+    var body: some View {
+        Table(packets, selection: $selection) {
+            TableColumn("Time") { pkt in
+                Text(pkt.timestamp.formatted(date: .omitted, time: .standard))
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundStyle(.secondary)
+            }
+            .width(min: 70, ideal: 80)
+
+            TableColumn("From") { pkt in
+                Text(pkt.fromDisplay)
+                    .font(.system(.body, design: .monospaced))
+                    .foregroundStyle(rowForeground(pkt))
+            }
+            .width(min: 80, ideal: 100)
+
+            TableColumn("To") { pkt in
+                Text(pkt.toDisplay)
+                    .font(.system(.body, design: .monospaced))
+                    .foregroundStyle(rowForeground(pkt))
+            }
+            .width(min: 80, ideal: 100)
+
+            TableColumn("Via") { pkt in
+                Text(pkt.viaDisplay.isEmpty ? "" : pkt.viaDisplay)
+                    .font(.system(.body, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            .width(min: 60, ideal: 120)
+
+            TableColumn("Type") { pkt in
+                Text(pkt.frameType.icon)
+                    .font(.system(.body))
+                    .foregroundStyle(rowForeground(pkt))
+                    .help(pkt.frameType.displayName)
+            }
+            .width(min: 40, ideal: 50)
+
+            TableColumn("Info") { pkt in
+                Text(pkt.infoPreview)
+                    .font(.system(.body, design: .monospaced))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .foregroundStyle(pkt.isLowSignal ? .secondary : .primary)
+                    .help(pkt.infoTooltip)
+            }
+        }
+    }
+
+    private func rowForeground(_ packet: Packet) -> Color {
+        packet.isLowSignal ? .secondary : .primary
+    }
+}
+

--- a/AXTerm/PayloadFormatter.swift
+++ b/AXTerm/PayloadFormatter.swift
@@ -1,0 +1,37 @@
+//
+//  PayloadFormatter.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 1/28/26.
+//
+
+import Foundation
+
+enum PayloadFormatter {
+    static let defaultBytesPerLine: Int = 16
+
+    static func hexString(_ data: Data, bytesPerLine: Int = defaultBytesPerLine) -> String {
+        guard !data.isEmpty else { return "" }
+        var result = ""
+        for (index, byte) in data.enumerated() {
+            if index > 0 && index % bytesPerLine == 0 {
+                result += "\n"
+            } else if index > 0 {
+                result += " "
+            }
+            result += String(format: "%02X", byte)
+        }
+        return result
+    }
+
+    static func asciiString(_ data: Data) -> String {
+        guard !data.isEmpty else { return "" }
+        return data.map { byte in
+            if byte >= 0x20 && byte <= 0x7E,
+               let scalar = UnicodeScalar(Int(byte)) {
+                return Character(scalar)
+            }
+            return "·"
+        }.map(String.init).joined()
+    }
+}

--- a/AXTerm/RawView.swift
+++ b/AXTerm/RawView.swift
@@ -1,0 +1,102 @@
+//
+//  RawView.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 1/28/26.
+//
+
+import SwiftUI
+import AppKit
+
+struct RawView: View {
+    let chunks: [RawChunk]
+    let onClear: () -> Void
+
+    @State private var autoScroll = true
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Toggle("Auto-scroll", isOn: $autoScroll)
+                    .toggleStyle(.checkbox)
+
+                Spacer()
+
+                Text("\(chunks.count) chunks")
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+
+                Button("Clear") {
+                    onClear()
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+            .background(.bar)
+
+            Divider()
+
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 4) {
+                        ForEach(chunks) { chunk in
+                            RawChunkView(chunk: chunk)
+                                .id(chunk.id)
+                        }
+                    }
+                    .padding()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .onChange(of: chunks.count) { _, _ in
+                    if autoScroll, let lastChunk = chunks.last {
+                        withAnimation(.easeOut(duration: 0.1)) {
+                            proxy.scrollTo(lastChunk.id, anchor: .bottom)
+                        }
+                    }
+                }
+            }
+            .background(.background)
+        }
+    }
+}
+
+struct RawChunkView: View {
+    let chunk: RawChunk
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text(chunk.timestampString)
+                    .foregroundStyle(.secondary)
+
+                Text("[\(chunk.data.count) bytes]")
+                    .foregroundStyle(.tertiary)
+
+                Spacer()
+
+                Button {
+                    copyToPasteboard(chunk.hex)
+                } label: {
+                    Image(systemName: "doc.on.doc")
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.small)
+            }
+
+            Text(chunk.hex)
+                .font(.system(.caption, design: .monospaced))
+                .textSelection(.enabled)
+                .lineLimit(4)
+        }
+        .padding(8)
+        .background(.background.secondary)
+        .cornerRadius(6)
+    }
+
+    private func copyToPasteboard(_ text: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+    }
+}

--- a/AXTerm/Station.swift
+++ b/AXTerm/Station.swift
@@ -9,6 +9,12 @@ import Foundation
 
 /// Represents a heard station for MHeard tracking
 struct Station: Identifiable, Hashable {
+    private static let timeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss"
+        return formatter
+    }()
+
     let call: String
     var lastHeard: Date?
     var heardCount: Int
@@ -27,10 +33,13 @@ struct Station: Identifiable, Hashable {
         var parts: [String] = []
         parts.append("\(heardCount) pkt\(heardCount == 1 ? "" : "s")")
         if let date = lastHeard {
-            let formatter = DateFormatter()
-            formatter.dateFormat = "HH:mm:ss"
-            parts.append(formatter.string(from: date))
+            parts.append(Self.timeFormatter.string(from: date))
         }
         return parts.joined(separator: " | ")
+    }
+
+    var lastViaDisplay: String {
+        guard !lastVia.isEmpty else { return "" }
+        return lastVia.joined(separator: ", ")
     }
 }

--- a/AXTerm/StationRowView.swift
+++ b/AXTerm/StationRowView.swift
@@ -1,0 +1,44 @@
+//
+//  StationRowView.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 1/28/26.
+//
+
+import SwiftUI
+
+struct StationRowView: View {
+    let station: Station
+    let isSelected: Bool
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(station.call)
+                    .font(.system(.body, design: .monospaced))
+                    .fontWeight(isSelected ? .semibold : .regular)
+
+                Text(station.subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                if !station.lastViaDisplay.isEmpty {
+                    Text("Via \(station.lastViaDisplay)")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Spacer()
+
+            if isSelected {
+                Image(systemName: "checkmark")
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 2)
+        .background(isSelected ? Color.accentColor.opacity(0.1) : Color.clear)
+        .cornerRadius(4)
+    }
+}
+

--- a/AXTerm/StationTracker.swift
+++ b/AXTerm/StationTracker.swift
@@ -1,0 +1,50 @@
+//
+//  StationTracker.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 1/28/26.
+//
+
+import Foundation
+
+struct StationTracker {
+    private(set) var stations: [Station] = []
+    private var stationIndex: [String: Int] = [:]
+
+    mutating func update(with packet: Packet) {
+        guard let from = packet.from else { return }
+        let call = from.display
+
+        if let index = stationIndex[call] {
+            stations[index].lastHeard = packet.timestamp
+            stations[index].heardCount += 1
+            if !packet.via.isEmpty {
+                stations[index].lastVia = packet.via.map { $0.display }
+            }
+        } else {
+            let station = Station(
+                call: call,
+                lastHeard: packet.timestamp,
+                heardCount: 1,
+                lastVia: packet.via.map { $0.display }
+            )
+            stations.append(station)
+            stationIndex[call] = stations.count - 1
+        }
+
+        sortStations()
+    }
+
+    mutating func reset() {
+        stations.removeAll()
+        stationIndex.removeAll()
+    }
+
+    private mutating func sortStations() {
+        stations.sort { ($0.lastHeard ?? .distantPast) > ($1.lastHeard ?? .distantPast) }
+        stationIndex.removeAll()
+        for (index, station) in stations.enumerated() {
+            stationIndex[station.call] = index
+        }
+    }
+}

--- a/AXTerm/String+Truncate.swift
+++ b/AXTerm/String+Truncate.swift
@@ -1,0 +1,24 @@
+//
+//  String+Truncate.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 1/28/26.
+//
+
+import Foundation
+
+extension String {
+    func wordSafeTruncate(limit: Int, trailing: String = "...") -> String {
+        guard count > limit else { return self }
+        let truncatedLimit = max(0, limit - trailing.count)
+        let endIndex = index(startIndex, offsetBy: truncatedLimit, limitedBy: endIndex) ?? endIndex
+        let prefix = String(self[..<endIndex])
+
+        if let lastWhitespace = prefix.lastIndex(where: { $0.isWhitespace }) {
+            let trimmed = prefix[..<lastWhitespace]
+            return trimmed.isEmpty ? String(prefix) + trailing : String(trimmed) + trailing
+        }
+
+        return prefix + trailing
+    }
+}

--- a/AXTermTests/AXTermTests.swift
+++ b/AXTermTests/AXTermTests.swift
@@ -54,7 +54,7 @@ final class AXTermTests: XCTestCase {
         let longInfo = String(repeating: "A", count: 100)
         let packet = Packet(info: longInfo.data(using: .ascii)!)
 
-        XCTAssertTrue(packet.infoPreview.count <= 80)
+        XCTAssertTrue(packet.infoPreview.count <= Packet.infoPreviewLimit)
         XCTAssertTrue(packet.infoPreview.hasSuffix("..."))
     }
 
@@ -74,6 +74,14 @@ final class AXTermTests: XCTestCase {
         XCTAssertEqual(FrameType.s.displayName, "S")
         XCTAssertEqual(FrameType.u.displayName, "U")
         XCTAssertEqual(FrameType.unknown.displayName, "?")
+    }
+
+    func testFrameTypeIconMapping() {
+        XCTAssertEqual(FrameType.ui.icon, "📡")
+        XCTAssertEqual(FrameType.i.icon, "💬")
+        XCTAssertEqual(FrameType.s.icon, "🔁")
+        XCTAssertEqual(FrameType.u.icon, "⚙️")
+        XCTAssertEqual(FrameType.unknown.icon, "❓")
     }
 
     // MARK: - ConsoleLine Tests

--- a/AXTermTests/CappedArrayTests.swift
+++ b/AXTermTests/CappedArrayTests.swift
@@ -1,0 +1,22 @@
+//
+//  CappedArrayTests.swift
+//  AXTermTests
+//
+//  Created by Ross Wardrup on 1/28/26.
+//
+
+import XCTest
+@testable import AXTerm
+
+final class CappedArrayTests: XCTestCase {
+
+    func testCappedArrayMaintainsMaxSize() {
+        var values: [Int] = []
+
+        for index in 1...5 {
+            CappedArray.append(index, to: &values, max: 3)
+        }
+
+        XCTAssertEqual(values, [3, 4, 5])
+    }
+}

--- a/AXTermTests/FilteringTests.swift
+++ b/AXTermTests/FilteringTests.swift
@@ -51,7 +51,7 @@ final class FilteringTests: XCTestCase {
         let packets = createTestPackets()
         let filters = PacketFilters()
 
-        let filtered = filterPackets(packets, search: "", filters: filters, stationCall: "N0CALL-1")
+        let filtered = PacketFilter.filter(packets: packets, search: "", filters: filters, stationCall: "N0CALL-1")
 
         XCTAssertEqual(filtered.count, 3)
         XCTAssertTrue(filtered.allSatisfy { $0.fromDisplay == "N0CALL-1" })
@@ -61,7 +61,7 @@ final class FilteringTests: XCTestCase {
         let packets = createTestPackets()
         let filters = PacketFilters()
 
-        let filtered = filterPackets(packets, search: "", filters: filters, stationCall: "NOBODY")
+        let filtered = PacketFilter.filter(packets: packets, search: "", filters: filters, stationCall: "NOBODY")
 
         XCTAssertEqual(filtered.count, 0)
     }
@@ -75,7 +75,7 @@ final class FilteringTests: XCTestCase {
         filters.showS = false
         filters.showU = false
 
-        let filtered = filterPackets(packets, search: "", filters: filters, stationCall: nil)
+        let filtered = PacketFilter.filter(packets: packets, search: "", filters: filters, stationCall: nil)
 
         XCTAssertEqual(filtered.count, 2)
         XCTAssertTrue(filtered.allSatisfy { $0.frameType == .ui })
@@ -88,7 +88,7 @@ final class FilteringTests: XCTestCase {
         filters.showS = false
         filters.showU = false
 
-        let filtered = filterPackets(packets, search: "", filters: filters, stationCall: nil)
+        let filtered = PacketFilter.filter(packets: packets, search: "", filters: filters, stationCall: nil)
 
         XCTAssertEqual(filtered.count, 1)
         XCTAssertEqual(filtered[0].frameType, .i)
@@ -102,7 +102,7 @@ final class FilteringTests: XCTestCase {
         filters.showS = false
         filters.showU = false
 
-        let filtered = filterPackets(packets, search: "", filters: filters, stationCall: nil)
+        let filtered = PacketFilter.filter(packets: packets, search: "", filters: filters, stationCall: nil)
 
         XCTAssertEqual(filtered.count, 0)
     }
@@ -114,7 +114,7 @@ final class FilteringTests: XCTestCase {
         var filters = PacketFilters()
         filters.onlyWithInfo = true
 
-        let filtered = filterPackets(packets, search: "", filters: filters, stationCall: nil)
+        let filtered = PacketFilter.filter(packets: packets, search: "", filters: filters, stationCall: nil)
 
         // Only packets with non-empty, printable info
         XCTAssertTrue(filtered.allSatisfy { $0.infoText != nil })
@@ -126,7 +126,7 @@ final class FilteringTests: XCTestCase {
         let packets = createTestPackets()
         let filters = PacketFilters()
 
-        let filtered = filterPackets(packets, search: "W0ABC", filters: filters, stationCall: nil)
+        let filtered = PacketFilter.filter(packets: packets, search: "W0ABC", filters: filters, stationCall: nil)
 
         XCTAssertEqual(filtered.count, 1)
         XCTAssertEqual(filtered[0].fromDisplay, "W0ABC")
@@ -136,7 +136,7 @@ final class FilteringTests: XCTestCase {
         let packets = createTestPackets()
         let filters = PacketFilters()
 
-        let filtered = filterPackets(packets, search: "W0XYZ", filters: filters, stationCall: nil)
+        let filtered = PacketFilter.filter(packets: packets, search: "W0XYZ", filters: filters, stationCall: nil)
 
         XCTAssertEqual(filtered.count, 1)
         XCTAssertEqual(filtered[0].toDisplay, "W0XYZ")
@@ -146,7 +146,7 @@ final class FilteringTests: XCTestCase {
         let packets = createTestPackets()
         let filters = PacketFilters()
 
-        let filtered = filterPackets(packets, search: "WIDE1", filters: filters, stationCall: nil)
+        let filtered = PacketFilter.filter(packets: packets, search: "WIDE1", filters: filters, stationCall: nil)
 
         XCTAssertEqual(filtered.count, 1)
         XCTAssertTrue(filtered[0].viaDisplay.contains("WIDE1"))
@@ -156,7 +156,7 @@ final class FilteringTests: XCTestCase {
         let packets = createTestPackets()
         let filters = PacketFilters()
 
-        let filtered = filterPackets(packets, search: "Position", filters: filters, stationCall: nil)
+        let filtered = PacketFilter.filter(packets: packets, search: "Position", filters: filters, stationCall: nil)
 
         XCTAssertEqual(filtered.count, 1)
         XCTAssertTrue(filtered[0].infoText?.contains("Position") ?? false)
@@ -166,7 +166,7 @@ final class FilteringTests: XCTestCase {
         let packets = createTestPackets()
         let filters = PacketFilters()
 
-        let filtered = filterPackets(packets, search: "position", filters: filters, stationCall: nil)
+        let filtered = PacketFilter.filter(packets: packets, search: "position", filters: filters, stationCall: nil)
 
         XCTAssertEqual(filtered.count, 1)
     }
@@ -175,7 +175,7 @@ final class FilteringTests: XCTestCase {
         let packets = createTestPackets()
         let filters = PacketFilters()
 
-        let filtered = filterPackets(packets, search: "ZZZZZ", filters: filters, stationCall: nil)
+        let filtered = PacketFilter.filter(packets: packets, search: "ZZZZZ", filters: filters, stationCall: nil)
 
         XCTAssertEqual(filtered.count, 0)
     }
@@ -190,7 +190,7 @@ final class FilteringTests: XCTestCase {
         filters.showU = false
         filters.onlyWithInfo = true
 
-        let filtered = filterPackets(packets, search: "APRS", filters: filters, stationCall: nil)
+        let filtered = PacketFilter.filter(packets: packets, search: "APRS", filters: filters, stationCall: nil)
 
         // UI frames only, with info, matching "APRS"
         XCTAssertEqual(filtered.count, 2)
@@ -216,34 +216,4 @@ final class FilteringTests: XCTestCase {
         XCTAssertTrue(filters.allows(frameType: .i))
     }
 
-    // MARK: - Helper
-
-    private func filterPackets(_ packets: [Packet], search: String, filters: PacketFilters, stationCall: String?) -> [Packet] {
-        packets.filter { packet in
-            // Station filter
-            if let call = stationCall {
-                guard packet.fromDisplay == call else { return false }
-            }
-
-            // Frame type filter
-            guard filters.allows(frameType: packet.frameType) else { return false }
-
-            // Only with info filter
-            if filters.onlyWithInfo && packet.infoText == nil {
-                return false
-            }
-
-            // Search filter
-            if !search.isEmpty {
-                let searchLower = search.lowercased()
-                let matches = packet.fromDisplay.lowercased().contains(searchLower) ||
-                              packet.toDisplay.lowercased().contains(searchLower) ||
-                              packet.viaDisplay.lowercased().contains(searchLower) ||
-                              (packet.infoText?.lowercased().contains(searchLower) ?? false)
-                guard matches else { return false }
-            }
-
-            return true
-        }
-    }
 }

--- a/AXTermTests/MHeardTests.swift
+++ b/AXTermTests/MHeardTests.swift
@@ -10,6 +10,35 @@ import XCTest
 
 final class MHeardTests: XCTestCase {
 
+    func testStationTrackerUpdatesCountAndVia() {
+        let now = Date()
+        let later = now.addingTimeInterval(10)
+        var tracker = StationTracker()
+
+        let firstPacket = Packet(
+            timestamp: now,
+            from: AX25Address(call: "N0CALL", ssid: 1),
+            via: [AX25Address(call: "WIDE1", ssid: 1)]
+        )
+        tracker.update(with: firstPacket)
+
+        XCTAssertEqual(tracker.stations.count, 1)
+        XCTAssertEqual(tracker.stations.first?.heardCount, 1)
+        XCTAssertEqual(tracker.stations.first?.lastVia, ["WIDE1-1"])
+
+        let secondPacket = Packet(
+            timestamp: later,
+            from: AX25Address(call: "N0CALL", ssid: 1),
+            via: [AX25Address(call: "WIDE2", ssid: 1)]
+        )
+        tracker.update(with: secondPacket)
+
+        XCTAssertEqual(tracker.stations.count, 1)
+        XCTAssertEqual(tracker.stations.first?.heardCount, 2)
+        XCTAssertEqual(tracker.stations.first?.lastHeard, later)
+        XCTAssertEqual(tracker.stations.first?.lastVia, ["WIDE2-1"])
+    }
+
     func testStationHeardCountIncrements() {
         // Test that Station struct tracks heardCount correctly
         var testStation = Station(call: "N0CALL-1", heardCount: 0)

--- a/AXTermTests/PayloadFormatterTests.swift
+++ b/AXTermTests/PayloadFormatterTests.swift
@@ -1,0 +1,24 @@
+//
+//  PayloadFormatterTests.swift
+//  AXTermTests
+//
+//  Created by Ross Wardrup on 1/28/26.
+//
+
+import XCTest
+@testable import AXTerm
+
+final class PayloadFormatterTests: XCTestCase {
+
+    func testASCIIStringReplacesNonPrintable() {
+        let data = Data([0x41, 0x42, 0x00, 0x7F, 0x20])
+        let result = PayloadFormatter.asciiString(data)
+        XCTAssertEqual(result, "AB·· ")
+    }
+
+    func testHexStringFormatting() {
+        let data = Data([0x01, 0x02, 0x03, 0x04])
+        let result = PayloadFormatter.hexString(data, bytesPerLine: 2)
+        XCTAssertEqual(result, "01 02\n03 04")
+    }
+}


### PR DESCRIPTION
### Motivation

- Improve packet table scanability and reduce visual noise by using compact icons for frame types and dimming low-value frames.  
- Give power users quick access to payload data (hex and ASCII) and reliable copy actions while keeping inspector layout tidy.  
- Split large view code into small reusable components and extract pure helpers to make behavior easier to test and maintain.

### Description

- UI: Replace textual frame type with icons via `FrameType.icon`, add `PacketTableView`, `ConsoleView`, `RawView`, and `StationRowView` to break up `ContentView`, wire tooltips, monospaced `Info` column, and dim low-signal rows (`Packet.isLowSignal`).  
- Inspector: Add a segmented `Payload` view (Hex/ASCII), `Copy Info` / `Copy Hex` / `Copy ASCII` actions, and improved GroupBox/grid layout in `PacketInspectorView`.  
- Utilities & refactor: Add `PayloadFormatter` (hex and ASCII renderers), `String.wordSafeTruncate` helper, `CappedArray` helper, `PacketFilter` extractor, and `StationTracker` for MHeard logic to keep parsing/networking separate from presentation.  
- Client & toolbar: Integrate `StationTracker` and `PacketFilter` into `KISSTcpClient`, add human-readable connection status in toolbar with subtle animation, disable filter toggles when no packets exist, and surface connected host/port.  
- Shortcuts: Add `AXTermCommands` to provide macOS-native keyboard shortcuts (`⌘F`, `⌘K`, `⌘I`, `⌘1/2/3`) via focused values and actions.  
- Tests: Add/adjust unit tests for payload formatting, capped arrays, filter behavior, MHeard updates, and frame-icon mapping; tests are pure XCTest and do not depend on UI rendering.

### Testing

- New and updated tests added: `PayloadFormatterTests` (ASCII/hex rendering), `CappedArrayTests` (capped behavior), updates to `MHeardTests` (station tracker last-heard/via/count), `FilteringTests` (uses `PacketFilter`), and `AXTermTests` (frame icon mapping and preview limits).  
- Attempted to run unit tests with `xcodebuild test -scheme AXTerm -destination 'platform=macOS'`, but `xcodebuild` is not available in this environment so tests were not executed here.  
- All new tests are non-UI `XCTest` cases and are intended to run in CI or a local Xcode environment where `xcodebuild`/Xcode are available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a7e595aec8330bc6388f7642bebf6)