### PR TITLE
Fix packet inspector selection and add payload tooling

### DIFF
--- a/AXTerm/PacketExport.swift
+++ b/AXTerm/PacketExport.swift
@@ -1,0 +1,41 @@
+//
+//  PacketExport.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 1/30/26.
+//
+
+import Foundation
+
+struct PacketExport: Codable, Equatable {
+    let id: UUID
+    let timestamp: Date
+    let from: String
+    let to: String
+    let via: [String]
+    let frameType: String
+    let pid: UInt8?
+    let infoHex: String
+    let infoASCII: String?
+    let rawAx25Hex: String
+
+    init(packet: Packet) {
+        id = packet.id
+        timestamp = packet.timestamp
+        from = packet.fromDisplay
+        to = packet.toDisplay
+        via = packet.via.map { $0.display }
+        frameType = packet.frameType.displayName
+        pid = packet.pid
+        infoHex = PayloadFormatter.hexString(packet.info)
+        infoASCII = packet.infoText
+        rawAx25Hex = PayloadFormatter.hexString(packet.rawAx25)
+    }
+
+    func jsonString() -> String? {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        return try? String(data: encoder.encode(self), encoding: .utf8)
+    }
+}

--- a/AXTerm/PacketFilter.swift
+++ b/AXTerm/PacketFilter.swift
@@ -12,7 +12,8 @@ enum PacketFilter {
         packets: [Packet],
         search: String,
         filters: PacketFilters,
-        stationCall: String?
+        stationCall: String?,
+        pinnedIDs: Set<Packet.ID> = []
     ) -> [Packet] {
         packets.filter { packet in
             if let call = stationCall {
@@ -22,6 +23,10 @@ enum PacketFilter {
             guard filters.allows(frameType: packet.frameType) else { return false }
 
             if filters.onlyWithInfo && packet.infoText == nil {
+                return false
+            }
+
+            if filters.onlyPinned && !pinnedIDs.contains(packet.id) {
                 return false
             }
 

--- a/AXTerm/PacketInspectorSelection.swift
+++ b/AXTerm/PacketInspectorSelection.swift
@@ -1,0 +1,12 @@
+//
+//  PacketInspectorSelection.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 1/30/26.
+//
+
+import Foundation
+
+struct PacketInspectorSelection: Identifiable, Hashable {
+    let id: Packet.ID
+}

--- a/AXTerm/PacketInspectorView.swift
+++ b/AXTerm/PacketInspectorView.swift
@@ -10,6 +10,9 @@ import AppKit
 
 struct PacketInspectorView: View {
     let packet: Packet
+    var isPinned: Bool
+    var onTogglePin: (() -> Void)?
+    var onFilterStation: ((String) -> Void)?
     var onClose: (() -> Void)?
 
     private enum PayloadViewMode: String, CaseIterable {
@@ -17,54 +20,184 @@ struct PacketInspectorView: View {
         case ascii = "ASCII"
     }
 
-    init(packet: Packet, onClose: (() -> Void)? = nil) {
+    private enum InspectorTab: String, CaseIterable {
+        case summary = "Summary"
+        case payload = "Payload"
+        case raw = "Raw"
+    }
+
+    init(
+        packet: Packet,
+        isPinned: Bool = false,
+        onTogglePin: (() -> Void)? = nil,
+        onFilterStation: ((String) -> Void)? = nil,
+        onClose: (() -> Void)? = nil
+    ) {
         self.packet = packet
+        self.isPinned = isPinned
+        self.onTogglePin = onTogglePin
+        self.onFilterStation = onFilterStation
         self.onClose = onClose
     }
 
     @Environment(\.dismiss) private var dismiss
     @State private var payloadViewMode: PayloadViewMode = .hex
+    @State private var selectedTab: InspectorTab = .summary
+    @State private var renderFullPayload: Bool = false
+    @State private var renderFullRaw: Bool = false
+    @State private var findQuery: String = ""
+    @FocusState private var isFindFocused: Bool
 
-    private let infoPreviewHeight: CGFloat = 150
-    private let payloadPreviewHeight: CGFloat = 160
-    private let rawPreviewHeight: CGFloat = 120
+    private let payloadPreviewLimit: Int = 2048
+    private let rawPreviewLimit: Int = 2048
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // Header
-            HStack {
-                Text("Packet Inspector")
-                    .font(.headline)
-
-                Spacer()
-
-                Button("Close") {
-                    onClose?()
-                    dismiss()
-                }
-                .keyboardShortcut(.cancelAction)
-            }
-            .padding()
-            .background(.bar)
+            header
 
             Divider()
 
-            // Content
+            Picker("Inspector Tab", selection: $selectedTab) {
+                ForEach(InspectorTab.allCases, id: \.self) { tab in
+                    Text(tab.rawValue)
+                        .tag(tab)
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding([.horizontal, .top])
+
+            Divider()
+
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
-                    addressSection
-                    frameSection
-                    infoSection
-                    payloadSection
-                    rawSection
+                    switch selectedTab {
+                    case .summary:
+                        summaryTab
+                    case .payload:
+                        payloadTab
+                    case .raw:
+                        rawTab
+                    }
                 }
                 .padding()
             }
         }
-        .frame(minWidth: 500, idealWidth: 600, minHeight: 400, idealHeight: 500)
+        .frame(minWidth: 560, idealWidth: 700, minHeight: 420, idealHeight: 540)
     }
 
-    // MARK: - Sections
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(alignment: .center, spacing: 12) {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 8) {
+                    Text(packet.fromDisplay)
+                        .font(.title3.weight(.semibold))
+                    Image(systemName: "arrow.right")
+                        .font(.body.weight(.medium))
+                        .foregroundStyle(.secondary)
+                    Text(packet.toDisplay)
+                        .font(.title3.weight(.semibold))
+                }
+
+                HStack(spacing: 10) {
+                    Text(packet.frameType.displayName)
+                        .font(.subheadline.weight(.medium))
+                    Text(packet.frameType.icon)
+                    Text(packet.timestamp, style: .date)
+                        .foregroundStyle(.secondary)
+                    Text(packet.timestamp, style: .time)
+                        .foregroundStyle(.secondary)
+                }
+                .font(.subheadline)
+            }
+
+            Spacer()
+
+            Button {
+                onTogglePin?()
+            } label: {
+                Image(systemName: isPinned ? "pin.fill" : "pin")
+            }
+            .buttonStyle(.bordered)
+            .help(isPinned ? "Unpin Packet" : "Pin Packet")
+
+            Button("Close") {
+                onClose?()
+                dismiss()
+            }
+            .keyboardShortcut(.cancelAction)
+        }
+        .padding()
+        .background(.bar)
+    }
+
+    // MARK: - Tabs
+
+    private var summaryTab: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            addressSection
+            pathSection
+            frameSection
+            actionSection
+            detectionSection
+        }
+    }
+
+    private var payloadTab: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            payloadToolbar
+            payloadFindBar
+            payloadContent
+        }
+    }
+
+    private var rawTab: some View {
+        GroupBox("Raw AX.25") {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack {
+                    Text("\(packet.rawAx25.count) bytes")
+                        .foregroundStyle(.secondary)
+
+                    Spacer()
+
+                    Button("Copy Hex") {
+                        copyToClipboard(PayloadFormatter.hexString(packet.rawAx25))
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                }
+
+                if packet.rawAx25.count > rawPreviewLimit && !renderFullRaw {
+                    HStack(spacing: 12) {
+                        Label("Showing first \(rawPreviewLimit) bytes", systemImage: "eye")
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Button("Render full") {
+                            renderFullRaw = true
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                    }
+                }
+
+                ScrollView {
+                    Text(rawText)
+                        .font(.system(.caption, design: .monospaced))
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .frame(maxHeight: 220)
+                .padding(8)
+                .background(.background.secondary)
+                .cornerRadius(6)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, 4)
+        }
+    }
+
+    // MARK: - Summary Sections
 
     private var addressSection: some View {
         GroupBox("Addresses") {
@@ -85,20 +218,42 @@ struct PacketInspectorView: View {
                         .textSelection(.enabled)
                 }
 
-                if !packet.via.isEmpty {
-                    GridRow {
-                        Text("Via:")
-                            .foregroundStyle(.secondary)
-                        Text(packet.viaDisplay)
-                            .font(.system(.body, design: .monospaced))
-                            .textSelection(.enabled)
-                    }
-                }
-
                 GridRow {
                     Text("Time:")
                         .foregroundStyle(.secondary)
                     Text(packet.timestamp, style: .date) + Text(" ") + Text(packet.timestamp, style: .time)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, 4)
+        }
+    }
+
+    private var pathSection: some View {
+        GroupBox("Path") {
+            VStack(alignment: .leading, spacing: 8) {
+                if packet.via.isEmpty {
+                    Text("Direct (no digipeaters)")
+                        .foregroundStyle(.secondary)
+                } else {
+                    HStack(spacing: 6) {
+                        ForEach(packet.via) { address in
+                            PathChip(address: address)
+                        }
+                    }
+                }
+
+                if !packet.via.isEmpty {
+                    Text("Heard via: \(packet.viaDisplay)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    let repeated = packet.via.filter { $0.repeated }
+                    if !repeated.isEmpty {
+                        Text("Repeated: \(repeated.map { $0.display }.joined(separator: ", "))")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -136,42 +291,94 @@ struct PacketInspectorView: View {
         }
     }
 
-    private var infoSection: some View {
-        GroupBox("Info") {
-            VStack(alignment: .leading, spacing: 8) {
-                HStack {
-                    Text("\(packet.info.count) bytes")
-                        .foregroundStyle(.secondary)
+    private var actionSection: some View {
+        GroupBox("Actions") {
+            HStack(spacing: 10) {
+                Button("Copy Info") {
+                    copyToClipboard(packet.infoText ?? "")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .disabled(packet.infoText == nil)
 
-                    Spacer()
+                Button("Copy Hex") {
+                    copyToClipboard(PayloadFormatter.hexString(packet.info))
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
 
-                    Button("Copy Info") {
-                        copyToClipboard(packet.infoText ?? "")
+                Button("Copy ASCII") {
+                    copyToClipboard(PayloadFormatter.asciiString(packet.info))
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+
+                Button("Export JSON") {
+                    if let json = PacketExport(packet: packet).jsonString() {
+                        copyToClipboard(json)
                     }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
-                    .disabled(packet.infoText == nil)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, 4)
+        }
+    }
+
+    private var detectionSection: some View {
+        let summary = payloadTokenSummary
+        return GroupBox("Detected") {
+            VStack(alignment: .leading, spacing: 10) {
+                if summary.isEmpty {
+                    Text("No tokens detected.")
+                        .foregroundStyle(.secondary)
                 }
 
-                if let text = packet.infoText {
-                    ScrollView {
-                        Text(text)
-                            .font(.system(.body, design: .monospaced))
-                            .textSelection(.enabled)
-                            .frame(maxWidth: .infinity, alignment: .leading)
+                if !summary.callsigns.isEmpty {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Callsigns")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        LazyVGrid(columns: [GridItem(.adaptive(minimum: 80), spacing: 8)], alignment: .leading, spacing: 8) {
+                            ForEach(summary.callsigns, id: \.self) { callsign in
+                                Button(callsign) {
+                                    onFilterStation?(callsign)
+                                }
+                                .buttonStyle(.link)
+                            }
+                        }
                     }
-                    .frame(maxHeight: infoPreviewHeight)
-                    .padding(8)
-                    .background(.background.secondary)
-                    .cornerRadius(4)
-                } else if packet.info.isEmpty {
-                    Text("(empty)")
-                        .foregroundStyle(.secondary)
-                        .italic()
-                } else {
-                    Text("(binary data)")
-                        .foregroundStyle(.secondary)
-                        .italic()
+                }
+
+                if !summary.frequencies.isEmpty {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Frequencies")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        LazyVGrid(columns: [GridItem(.adaptive(minimum: 120), spacing: 8)], alignment: .leading, spacing: 8) {
+                            ForEach(summary.frequencies, id: \.self) { freq in
+                                Button("Copy \(freq) MHz") {
+                                    copyToClipboard(freq)
+                                }
+                                .buttonStyle(.bordered)
+                                .controlSize(.small)
+                            }
+                        }
+                    }
+                }
+
+                if !summary.urls.isEmpty {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Links")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        ForEach(summary.urls, id: \.self) { url in
+                            Text(url)
+                                .font(.system(.body, design: .monospaced))
+                                .textSelection(.enabled)
+                        }
+                    }
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -179,9 +386,11 @@ struct PacketInspectorView: View {
         }
     }
 
-    private var payloadSection: some View {
+    // MARK: - Payload Tab
+
+    private var payloadToolbar: some View {
         GroupBox("Payload") {
-            VStack(alignment: .leading, spacing: 10) {
+            VStack(alignment: .leading, spacing: 12) {
                 HStack {
                     Picker("Payload View", selection: $payloadViewMode) {
                         ForEach(PayloadViewMode.allCases, id: \.self) { mode in
@@ -193,6 +402,13 @@ struct PacketInspectorView: View {
                     .frame(maxWidth: 180)
 
                     Spacer()
+
+                    Button("Copy Info") {
+                        copyToClipboard(packet.infoText ?? "")
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .disabled(packet.infoText == nil)
 
                     Button("Copy Hex") {
                         copyToClipboard(PayloadFormatter.hexString(packet.info))
@@ -207,50 +423,95 @@ struct PacketInspectorView: View {
                     .controlSize(.small)
                 }
 
-                ScrollView {
-                    Text(payloadText)
-                        .font(.system(.body, design: .monospaced))
-                        .textSelection(.enabled)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                HStack {
+                    Text("\(packet.info.count) bytes")
+                        .foregroundStyle(.secondary)
+
+                    Spacer()
+
+                    if packet.info.count > payloadPreviewLimit && !renderFullPayload {
+                        Button("Render full") {
+                            renderFullPayload = true
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                    }
                 }
-                .frame(maxHeight: payloadPreviewHeight)
-                .padding(8)
-                .background(.background.secondary)
-                .cornerRadius(4)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.vertical, 4)
         }
     }
 
-    private var rawSection: some View {
-        GroupBox("Raw AX.25") {
-            VStack(alignment: .leading, spacing: 8) {
-                HStack {
-                    Button("Copy Hex") {
-                        copyToClipboard(PayloadFormatter.hexString(packet.rawAx25))
-                    }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
-                }
+    private var payloadFindBar: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+            TextField("Find in payload", text: $findQuery)
+                .textFieldStyle(.roundedBorder)
+                .focused($isFindFocused)
 
-                ScrollView {
-                    Text(PayloadFormatter.hexString(packet.rawAx25))
-                        .font(.system(.caption, design: .monospaced))
-                        .textSelection(.enabled)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
-                .frame(maxHeight: rawPreviewHeight)
-                .padding(8)
-                .background(.background.secondary)
-                .cornerRadius(4)
+            Button("Find") {
+                isFindFocused = true
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.vertical, 4)
+            .keyboardShortcut("f", modifiers: [.command])
         }
+    }
+
+    private var payloadContent: some View {
+        ScrollView {
+            if findQuery.isEmpty {
+                Text(payloadText)
+                    .font(.system(.body, design: .monospaced))
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } else {
+                Text(highlightedPayload)
+                    .font(.system(.body, design: .monospaced))
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .frame(maxHeight: 260)
+        .padding(8)
+        .background(.background.secondary)
+        .cornerRadius(6)
     }
 
     // MARK: - Helpers
+
+    private var payloadTokenSummary: PayloadTokenSummary {
+        guard let text = packet.infoText, !text.isEmpty else {
+            return PayloadTokenSummary(callsigns: [], frequencies: [], urls: [])
+        }
+        return PayloadTokenExtractor.summarize(text: text)
+    }
+
+    private var payloadText: String {
+        let data = payloadData
+        switch payloadViewMode {
+        case .hex:
+            return PayloadFormatter.hexString(data)
+        case .ascii:
+            return PayloadFormatter.asciiString(data)
+        }
+    }
+
+    private var highlightedPayload: AttributedString {
+        PayloadSearchHighlighter.highlight(text: payloadText, query: findQuery)
+    }
+
+    private var payloadData: Data {
+        if renderFullPayload {
+            return packet.info
+        }
+        return packet.info.prefix(payloadPreviewLimit)
+    }
+
+    private var rawText: String {
+        let data = renderFullRaw ? packet.rawAx25 : packet.rawAx25.prefix(rawPreviewLimit)
+        return PayloadFormatter.hexString(data)
+    }
 
     private func pidDescription(_ pid: UInt8) -> String {
         switch pid {
@@ -276,14 +537,36 @@ struct PacketInspectorView: View {
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(s, forType: .string)
     }
+}
 
-    private var payloadText: String {
-        switch payloadViewMode {
-        case .hex:
-            return PayloadFormatter.hexString(packet.info)
-        case .ascii:
-            return PayloadFormatter.asciiString(packet.info)
+private struct PathChip: View {
+    let address: AX25Address
+
+    var body: some View {
+        Text(address.display)
+            .font(.system(.caption, design: .monospaced))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(
+                Capsule(style: .continuous)
+                    .fill(address.repeated ? Color.accentColor.opacity(0.2) : Color.secondary.opacity(0.15))
+            )
+            .foregroundStyle(address.repeated ? .primary : .secondary)
+    }
+}
+
+private enum PayloadSearchHighlighter {
+    static func highlight(text: String, query: String) -> AttributedString {
+        var attributed = AttributedString(text)
+        guard !query.isEmpty else { return attributed }
+
+        var searchRange = attributed.startIndex..<attributed.endIndex
+        while let range = attributed.range(of: query, options: [.caseInsensitive], range: searchRange) {
+            attributed[range].backgroundColor = .yellow.opacity(0.4)
+            searchRange = range.upperBound..<attributed.endIndex
         }
+
+        return attributed
     }
 }
 
@@ -295,7 +578,7 @@ struct PacketInspectorView: View {
             via: [AX25Address(call: "WIDE1", ssid: 1, repeated: true)],
             frameType: .ui,
             pid: 0xF0,
-            info: "!4903.50N/07201.75W-Test packet".data(using: .ascii)!,
+            info: "CQ CQ http://example.com 145.050 N0CALL".data(using: .ascii) ?? Data(),
             rawAx25: Data([0x82, 0xA0, 0xA4, 0xA6, 0x40, 0x40])
         )
     )

--- a/AXTerm/PacketSelectionResolver.swift
+++ b/AXTerm/PacketSelectionResolver.swift
@@ -1,0 +1,21 @@
+//
+//  PacketSelectionResolver.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 1/30/26.
+//
+
+import Foundation
+
+enum PacketSelectionResolver {
+    static func resolve(selection: Set<Packet.ID>, in packets: [Packet]) -> Packet? {
+        guard !selection.isEmpty else { return nil }
+        return packets.first { selection.contains($0.id) }
+    }
+
+    static func filteredSelection(_ selection: Set<Packet.ID>, for packets: [Packet]) -> Set<Packet.ID> {
+        guard !selection.isEmpty else { return [] }
+        let validIDs = Set(packets.map(\.id))
+        return selection.intersection(validIDs)
+    }
+}

--- a/AXTerm/PacketTableView.swift
+++ b/AXTerm/PacketTableView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct PacketTableView: View {
     let packets: [Packet]
     @Binding var selection: Set<Packet.ID>
+    let onInspect: (Packet) -> Void
 
     var body: some View {
         Table(packets, selection: $selection) {
@@ -17,6 +18,10 @@ struct PacketTableView: View {
                 Text(pkt.timestamp.formatted(date: .omitted, time: .standard))
                     .font(.system(.caption, design: .monospaced))
                     .foregroundStyle(.secondary)
+                    .contentShape(Rectangle())
+                    .onTapGesture(count: 2) {
+                        onInspect(pkt)
+                    }
             }
             .width(min: 70, ideal: 80)
 
@@ -24,6 +29,10 @@ struct PacketTableView: View {
                 Text(pkt.fromDisplay)
                     .font(.system(.body, design: .monospaced))
                     .foregroundStyle(rowForeground(pkt))
+                    .contentShape(Rectangle())
+                    .onTapGesture(count: 2) {
+                        onInspect(pkt)
+                    }
             }
             .width(min: 80, ideal: 100)
 
@@ -31,6 +40,10 @@ struct PacketTableView: View {
                 Text(pkt.toDisplay)
                     .font(.system(.body, design: .monospaced))
                     .foregroundStyle(rowForeground(pkt))
+                    .contentShape(Rectangle())
+                    .onTapGesture(count: 2) {
+                        onInspect(pkt)
+                    }
             }
             .width(min: 80, ideal: 100)
 
@@ -39,6 +52,10 @@ struct PacketTableView: View {
                     .font(.system(.body, design: .monospaced))
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
+                    .contentShape(Rectangle())
+                    .onTapGesture(count: 2) {
+                        onInspect(pkt)
+                    }
             }
             .width(min: 60, ideal: 120)
 
@@ -47,6 +64,10 @@ struct PacketTableView: View {
                     .font(.system(.body))
                     .foregroundStyle(rowForeground(pkt))
                     .help(pkt.frameType.displayName)
+                    .contentShape(Rectangle())
+                    .onTapGesture(count: 2) {
+                        onInspect(pkt)
+                    }
             }
             .width(min: 40, ideal: 50)
 
@@ -57,6 +78,10 @@ struct PacketTableView: View {
                     .truncationMode(.tail)
                     .foregroundStyle(pkt.isLowSignal ? .secondary : .primary)
                     .help(pkt.infoTooltip)
+                    .contentShape(Rectangle())
+                    .onTapGesture(count: 2) {
+                        onInspect(pkt)
+                    }
             }
         }
     }
@@ -65,4 +90,3 @@ struct PacketTableView: View {
         packet.isLowSignal ? .secondary : .primary
     }
 }
-

--- a/AXTerm/PayloadTokenExtractor.swift
+++ b/AXTerm/PayloadTokenExtractor.swift
@@ -1,0 +1,82 @@
+//
+//  PayloadTokenExtractor.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 1/30/26.
+//
+
+import Foundation
+
+struct PayloadTokenSummary: Equatable {
+    let callsigns: [String]
+    let frequencies: [String]
+    let urls: [String]
+
+    var isEmpty: Bool {
+        callsigns.isEmpty && frequencies.isEmpty && urls.isEmpty
+    }
+}
+
+enum PayloadTokenExtractor {
+    static func summarize(text: String) -> PayloadTokenSummary {
+        let normalized = text.uppercased()
+        let urls = extractURLs(from: text)
+        let callsigns = extractCallsigns(from: normalized, excluding: urls)
+        let freqs = extractFrequencies(from: text)
+        return PayloadTokenSummary(
+            callsigns: callsigns,
+            frequencies: freqs,
+            urls: urls
+        )
+    }
+
+    private static func extractURLs(from text: String) -> [String] {
+        guard let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else {
+            return []
+        }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        let matches = detector.matches(in: text, options: [], range: range)
+        var urls: [String] = []
+        for match in matches {
+            guard let url = match.url else { continue }
+            let absolute = url.absoluteString
+            if !urls.contains(absolute) {
+                urls.append(absolute)
+            }
+        }
+        return urls
+    }
+
+    private static func extractCallsigns(from text: String, excluding urls: [String]) -> [String] {
+        let urlSet = Set(urls.map { $0.uppercased() })
+        let regex = try? NSRegularExpression(pattern: "\\b[A-Z0-9]{1,6}(?:-[0-9]{1,2})?\\b")
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        let matches = regex?.matches(in: text, options: [], range: range) ?? []
+        var callsigns: [String] = []
+        for match in matches {
+            guard let range = Range(match.range, in: text) else { continue }
+            let token = String(text[range])
+            guard token.rangeOfCharacter(from: .letters) != nil else { continue }
+            guard !urlSet.contains(token) else { continue }
+            if !callsigns.contains(token) {
+                callsigns.append(token)
+            }
+        }
+        return callsigns
+    }
+
+    private static func extractFrequencies(from text: String) -> [String] {
+        let regex = try? NSRegularExpression(pattern: "\\b\\d{2,3}\\.\\d{1,4}\\b")
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        let matches = regex?.matches(in: text, options: [], range: range) ?? []
+        var freqs: [String] = []
+        for match in matches {
+            guard let range = Range(match.range, in: text) else { continue }
+            let token = String(text[range])
+            if !freqs.contains(token) {
+                freqs.append(token)
+            }
+        }
+        return freqs
+    }
+}

--- a/AXTermTests/FilteringTests.swift
+++ b/AXTermTests/FilteringTests.swift
@@ -120,6 +120,24 @@ final class FilteringTests: XCTestCase {
         XCTAssertTrue(filtered.allSatisfy { $0.infoText != nil })
     }
 
+    func testFilterOnlyPinned() {
+        let packets = createTestPackets()
+        var filters = PacketFilters()
+        filters.onlyPinned = true
+        let pinnedIDs: Set<Packet.ID> = [packets[1].id]
+
+        let filtered = PacketFilter.filter(
+            packets: packets,
+            search: "",
+            filters: filters,
+            stationCall: nil,
+            pinnedIDs: pinnedIDs
+        )
+
+        XCTAssertEqual(filtered.count, 1)
+        XCTAssertEqual(filtered.first?.id, packets[1].id)
+    }
+
     // MARK: - Search Filter Tests
 
     func testSearchMatchesFrom() {

--- a/AXTermTests/PacketSelectionResolverTests.swift
+++ b/AXTermTests/PacketSelectionResolverTests.swift
@@ -1,0 +1,54 @@
+//
+//  PacketSelectionResolverTests.swift
+//  AXTermTests
+//
+//  Created by Ross Wardrup on 1/30/26.
+//
+
+import XCTest
+@testable import AXTerm
+
+final class PacketSelectionResolverTests: XCTestCase {
+    func testResolveSelectionUsesProvidedOrder() {
+        let firstID = UUID()
+        let secondID = UUID()
+        let packets = [
+            Packet(id: secondID, from: AX25Address(call: "N0CALL")),
+            Packet(id: firstID, from: AX25Address(call: "W0ABC"))
+        ]
+        let selection: Set<Packet.ID> = [firstID, secondID]
+
+        let resolved = PacketSelectionResolver.resolve(selection: selection, in: packets)
+
+        XCTAssertEqual(resolved?.id, secondID)
+    }
+
+    func testResolveSelectionReturnsNilWhenMissing() {
+        let packets = [Packet(id: UUID(), from: AX25Address(call: "N0CALL"))]
+        let selection: Set<Packet.ID> = [UUID()]
+
+        let resolved = PacketSelectionResolver.resolve(selection: selection, in: packets)
+
+        XCTAssertNil(resolved)
+    }
+
+    func testFilteredSelectionRemovesMissingIDs() {
+        let keptID = UUID()
+        let droppedID = UUID()
+        let packets = [Packet(id: keptID, from: AX25Address(call: "N0CALL"))]
+        let selection: Set<Packet.ID> = [keptID, droppedID]
+
+        let filtered = PacketSelectionResolver.filteredSelection(selection, for: packets)
+
+        XCTAssertEqual(filtered, [keptID])
+    }
+
+    func testFilteredSelectionEmptyWhenSelectionCleared() {
+        let packets = [Packet(id: UUID(), from: AX25Address(call: "N0CALL"))]
+        let selection: Set<Packet.ID> = []
+
+        let filtered = PacketSelectionResolver.filteredSelection(selection, for: packets)
+
+        XCTAssertTrue(filtered.isEmpty)
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure packet inspection is robust when the packet list is filtered and the selection changes by resolving by ID against the visible rows instead of depending on transient object references.  
- Provide richer packet inspection capabilities (pinning, token detection, search/highlight, payload rendering limits, JSON export) to make analysis and sharing easier.  
- Improve table/keyboard/UX for opening an inspector (double‑click/command inspect) and keep inspector presentation stable as the packet model mutates.  

### Description
- Added an ID‑based resolver `PacketSelectionResolver` and `PacketInspectorSelection` to reliably map UI selection to the filtered `packets` array and to keep sheet presentation stable.  
- Reworked selection/inspection flow in `ContentView` to use `inspectorSelection`, sync selection with `filteredPackets`, and open the inspector via `openInspector(for:)`.  
- Added `PacketInspectorView` redesign with summary/payload/raw tabs, payload find/highlight, controlled rendering limits, pin toggle, copy/export actions, and token detection UI.  
- Introduced `PayloadTokenExtractor` to extract callsigns, frequencies, and URLs from payload text and `PacketExport` to serialize a `Packet` to pretty JSON.  
- Added pin state to the model in `KISSTcpClient` (`pinnedPacketIDs`) with `isPinned`, `togglePin(for:)`, and propagation into filtering; added `onlyPinned` filter to `PacketFilters` and wired it into `PacketFilter.filter`.  
- Made the table rows in `PacketTableView` respond to double‑click by invoking an `onInspect` callback, and kept selection synchronized when filters/search/stations/packets change.  
- Tests: added `PacketSelectionResolverTests` and extended `FilteringTests` with `testFilterOnlyPinned` to cover pinned filtering.  

### Testing
- Unit tests were added/updated: `AXTermTests/PacketSelectionResolverTests.swift` (new) and `AXTermTests/FilteringTests.swift` (updated) to exercise selection resolution and pinned filtering behavior.  
- Attempted to run the full test suite with `xcodebuild -project AXTerm.xcodeproj -scheme AXTerm -destination 'platform=macOS' test`, however `xcodebuild` is not available in this environment so automated test execution could not be completed.  
- No other automated test runs were performed in this environment; the change set is self‑contained and includes tests to run in a macOS Xcode environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a8502e9d8833089795019b2c259b5)