### PR TITLE
Row-wide inspect + minimal row context menu, improved JSON copy UX, callsign detection fix, and unit tests

### DIFF
--- a/AXTerm/ClipboardWriter.swift
+++ b/AXTerm/ClipboardWriter.swift
@@ -1,0 +1,15 @@
+//
+//  ClipboardWriter.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 2/1/26.
+//
+
+import AppKit
+
+enum ClipboardWriter {
+    static func copy(_ string: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(string, forType: .string)
+    }
+}

--- a/AXTerm/PacketExport.swift
+++ b/AXTerm/PacketExport.swift
@@ -38,4 +38,16 @@ struct PacketExport: Codable, Equatable {
         encoder.dateEncodingStrategy = .iso8601
         return try? String(data: encoder.encode(self), encoding: .utf8)
     }
+
+    func jsonData() throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        return try encoder.encode(self)
+    }
+
+    func writeJSON(to url: URL) throws {
+        let data = try jsonData()
+        try data.write(to: url, options: [.atomic])
+    }
 }

--- a/AXTerm/PacketInspectionCoordinator.swift
+++ b/AXTerm/PacketInspectionCoordinator.swift
@@ -1,0 +1,20 @@
+//
+//  PacketInspectionCoordinator.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 2/1/26.
+//
+
+import Foundation
+
+struct PacketInspectionCoordinator {
+    func inspectSelectedPacket(
+        selection: Set<Packet.ID>,
+        packets: [Packet]
+    ) -> PacketInspectorSelection? {
+        guard let packet = PacketSelectionResolver.resolve(selection: selection, in: packets) else {
+            return nil
+        }
+        return PacketInspectorSelection(id: packet.id)
+    }
+}

--- a/AXTerm/PacketTableView.swift
+++ b/AXTerm/PacketTableView.swift
@@ -10,83 +10,177 @@ import SwiftUI
 struct PacketTableView: View {
     let packets: [Packet]
     @Binding var selection: Set<Packet.ID>
-    let onInspect: (Packet) -> Void
+    let onInspectSelection: () -> Void
+    let onCopyInfo: (Packet) -> Void
+    let onCopyRawHex: (Packet) -> Void
 
     var body: some View {
         Table(packets, selection: $selection) {
             TableColumn("Time") { pkt in
-                Text(pkt.timestamp.formatted(date: .omitted, time: .standard))
-                    .font(.system(.caption, design: .monospaced))
-                    .foregroundStyle(.secondary)
-                    .contentShape(Rectangle())
-                    .onTapGesture(count: 2) {
-                        onInspect(pkt)
-                    }
+                PacketTableCell(
+                    packet: pkt,
+                    selection: $selection,
+                    onInspectSelection: onInspectSelection,
+                    onCopyInfo: onCopyInfo,
+                    onCopyRawHex: onCopyRawHex
+                ) {
+                    Text(pkt.timestamp.formatted(date: .omitted, time: .standard))
+                        .font(.system(.caption, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                }
             }
             .width(min: 70, ideal: 80)
 
             TableColumn("From") { pkt in
-                Text(pkt.fromDisplay)
-                    .font(.system(.body, design: .monospaced))
-                    .foregroundStyle(rowForeground(pkt))
-                    .contentShape(Rectangle())
-                    .onTapGesture(count: 2) {
-                        onInspect(pkt)
-                    }
+                PacketTableCell(
+                    packet: pkt,
+                    selection: $selection,
+                    onInspectSelection: onInspectSelection,
+                    onCopyInfo: onCopyInfo,
+                    onCopyRawHex: onCopyRawHex
+                ) {
+                    Text(pkt.fromDisplay)
+                        .font(.system(.body, design: .monospaced))
+                        .foregroundStyle(rowForeground(pkt))
+                }
             }
             .width(min: 80, ideal: 100)
 
             TableColumn("To") { pkt in
-                Text(pkt.toDisplay)
-                    .font(.system(.body, design: .monospaced))
-                    .foregroundStyle(rowForeground(pkt))
-                    .contentShape(Rectangle())
-                    .onTapGesture(count: 2) {
-                        onInspect(pkt)
-                    }
+                PacketTableCell(
+                    packet: pkt,
+                    selection: $selection,
+                    onInspectSelection: onInspectSelection,
+                    onCopyInfo: onCopyInfo,
+                    onCopyRawHex: onCopyRawHex
+                ) {
+                    Text(pkt.toDisplay)
+                        .font(.system(.body, design: .monospaced))
+                        .foregroundStyle(rowForeground(pkt))
+                }
             }
             .width(min: 80, ideal: 100)
 
             TableColumn("Via") { pkt in
-                Text(pkt.viaDisplay.isEmpty ? "" : pkt.viaDisplay)
-                    .font(.system(.body, design: .monospaced))
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                    .contentShape(Rectangle())
-                    .onTapGesture(count: 2) {
-                        onInspect(pkt)
-                    }
+                PacketTableCell(
+                    packet: pkt,
+                    selection: $selection,
+                    onInspectSelection: onInspectSelection,
+                    onCopyInfo: onCopyInfo,
+                    onCopyRawHex: onCopyRawHex
+                ) {
+                    Text(pkt.viaDisplay.isEmpty ? "" : pkt.viaDisplay)
+                        .font(.system(.body, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
             }
             .width(min: 60, ideal: 120)
 
             TableColumn("Type") { pkt in
-                Text(pkt.frameType.icon)
-                    .font(.system(.body))
-                    .foregroundStyle(rowForeground(pkt))
-                    .help(pkt.frameType.displayName)
-                    .contentShape(Rectangle())
-                    .onTapGesture(count: 2) {
-                        onInspect(pkt)
-                    }
+                PacketTableCell(
+                    packet: pkt,
+                    selection: $selection,
+                    onInspectSelection: onInspectSelection,
+                    onCopyInfo: onCopyInfo,
+                    onCopyRawHex: onCopyRawHex,
+                    alignment: .center
+                ) {
+                    Text(pkt.frameType.icon)
+                        .font(.system(.body))
+                        .foregroundStyle(rowForeground(pkt))
+                        .help(pkt.frameType.displayName)
+                }
             }
             .width(min: 40, ideal: 50)
 
             TableColumn("Info") { pkt in
-                Text(pkt.infoPreview)
-                    .font(.system(.body, design: .monospaced))
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                    .foregroundStyle(pkt.isLowSignal ? .secondary : .primary)
-                    .help(pkt.infoTooltip)
-                    .contentShape(Rectangle())
-                    .onTapGesture(count: 2) {
-                        onInspect(pkt)
-                    }
+                PacketTableCell(
+                    packet: pkt,
+                    selection: $selection,
+                    onInspectSelection: onInspectSelection,
+                    onCopyInfo: onCopyInfo,
+                    onCopyRawHex: onCopyRawHex
+                ) {
+                    Text(pkt.infoPreview)
+                        .font(.system(.body, design: .monospaced))
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .foregroundStyle(pkt.isLowSignal ? .secondary : .primary)
+                        .help(pkt.infoTooltip)
+                }
             }
+        }
+        .focusable(true)
+        .onKeyPress(.return) {
+            onInspectSelection()
+            return .handled
+        }
+        .onKeyPress(.enter) {
+            onInspectSelection()
+            return .handled
         }
     }
 
     private func rowForeground(_ packet: Packet) -> Color {
         packet.isLowSignal ? .secondary : .primary
+    }
+}
+
+private struct PacketTableCell<Content: View>: View {
+    let packet: Packet
+    @Binding var selection: Set<Packet.ID>
+    let onInspectSelection: () -> Void
+    let onCopyInfo: (Packet) -> Void
+    let onCopyRawHex: (Packet) -> Void
+    var alignment: Alignment = .leading
+    let content: Content
+
+    init(
+        packet: Packet,
+        selection: Binding<Set<Packet.ID>>,
+        onInspectSelection: @escaping () -> Void,
+        onCopyInfo: @escaping (Packet) -> Void,
+        onCopyRawHex: @escaping (Packet) -> Void,
+        alignment: Alignment = .leading,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.packet = packet
+        self._selection = selection
+        self.onInspectSelection = onInspectSelection
+        self.onCopyInfo = onCopyInfo
+        self.onCopyRawHex = onCopyRawHex
+        self.alignment = alignment
+        self.content = content()
+    }
+
+    var body: some View {
+        content
+            .frame(maxWidth: .infinity, alignment: alignment)
+            .contentShape(Rectangle())
+            .background(RowSelectionCaptureView {
+                selection = [packet.id]
+            })
+            .contextMenu {
+                Button("Inspect Packet") {
+                    selection = [packet.id]
+                    onInspectSelection()
+                }
+                .keyboardShortcut("i", modifiers: [.command])
+
+                Button("Copy Info") {
+                    selection = [packet.id]
+                    onCopyInfo(packet)
+                }
+
+                Button("Copy Raw Hex") {
+                    selection = [packet.id]
+                    onCopyRawHex(packet)
+                }
+            }
+            .onTapGesture(count: 2) {
+                selection = [packet.id]
+                onInspectSelection()
+            }
     }
 }

--- a/AXTerm/PayloadTokenExtractor.swift
+++ b/AXTerm/PayloadTokenExtractor.swift
@@ -49,13 +49,15 @@ enum PayloadTokenExtractor {
 
     private static func extractCallsigns(from text: String, excluding urls: [String]) -> [String] {
         let urlSet = Set(urls.map { $0.uppercased() })
-        let regex = try? NSRegularExpression(pattern: "\\b[A-Z0-9]{1,6}(?:-[0-9]{1,2})?\\b")
+        let pattern = "(?<![A-Z0-9])[A-Z0-9]{1,6}(?:-[0-9]{1,2})?(?:/[A-Z0-9]{1,2})?\\*?(?![A-Z0-9])"
+        let regex = try? NSRegularExpression(pattern: pattern)
         let range = NSRange(text.startIndex..<text.endIndex, in: text)
         let matches = regex?.matches(in: text, options: [], range: range) ?? []
         var callsigns: [String] = []
         for match in matches {
             guard let range = Range(match.range, in: text) else { continue }
             let token = String(text[range])
+            guard token.count > 1 else { continue }
             guard token.rangeOfCharacter(from: .letters) != nil else { continue }
             guard !urlSet.contains(token) else { continue }
             if !callsigns.contains(token) {

--- a/AXTerm/RowSelectionCaptureView.swift
+++ b/AXTerm/RowSelectionCaptureView.swift
@@ -1,0 +1,41 @@
+//
+//  RowSelectionCaptureView.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 2/1/26.
+//
+
+import SwiftUI
+import AppKit
+
+struct RowSelectionCaptureView: NSViewRepresentable {
+    let onSecondaryClick: () -> Void
+
+    func makeNSView(context: Context) -> NSView {
+        CaptureView(onSecondaryClick: onSecondaryClick)
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        guard let view = nsView as? CaptureView else { return }
+        view.onSecondaryClick = onSecondaryClick
+    }
+}
+
+private final class CaptureView: NSView {
+    var onSecondaryClick: () -> Void
+
+    init(onSecondaryClick: @escaping () -> Void) {
+        self.onSecondaryClick = onSecondaryClick
+        super.init(frame: .zero)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override func rightMouseDown(with event: NSEvent) {
+        onSecondaryClick()
+        super.rightMouseDown(with: event)
+    }
+}

--- a/AXTermTests/PacketExportTests.swift
+++ b/AXTermTests/PacketExportTests.swift
@@ -1,0 +1,52 @@
+//
+//  PacketExportTests.swift
+//  AXTermTests
+//
+//  Created by Ross Wardrup on 2/1/26.
+//
+
+import XCTest
+@testable import AXTerm
+
+final class PacketExportTests: XCTestCase {
+    func testJSONIncludesExpectedKeys() throws {
+        let packet = Packet(
+            id: UUID(),
+            timestamp: Date(timeIntervalSince1970: 0),
+            from: AX25Address(call: "N0CALL"),
+            to: AX25Address(call: "APRS"),
+            via: [AX25Address(call: "WIDE1", ssid: 1)],
+            frameType: .ui,
+            pid: 0xF0,
+            info: "CQ".data(using: .ascii) ?? Data(),
+            rawAx25: Data([0x01, 0x02])
+        )
+
+        let export = PacketExport(packet: packet)
+        let data = try export.jsonData()
+        let jsonObject = try JSONSerialization.jsonObject(with: data, options: [])
+        let dict = try XCTUnwrap(jsonObject as? [String: Any])
+
+        XCTAssertNotNil(dict["frameType"])
+        XCTAssertNotNil(dict["from"])
+        XCTAssertNotNil(dict["to"])
+        XCTAssertNotNil(dict["via"])
+        XCTAssertNotNil(dict["pid"])
+        XCTAssertNotNil(dict["timestamp"])
+        XCTAssertNotNil(dict["infoASCII"])
+        XCTAssertNotNil(dict["infoHex"])
+        XCTAssertNotNil(dict["rawAx25Hex"])
+        XCTAssertNotNil(dict["id"])
+    }
+
+    func testWriteJSONWritesFile() throws {
+        let packet = Packet(from: AX25Address(call: "N0CALL"))
+        let export = PacketExport(packet: packet)
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString).appendingPathExtension("json")
+
+        try export.writeJSON(to: tempURL)
+
+        let data = try Data(contentsOf: tempURL)
+        XCTAssertFalse(data.isEmpty)
+    }
+}

--- a/AXTermTests/PacketInspectionCoordinatorTests.swift
+++ b/AXTermTests/PacketInspectionCoordinatorTests.swift
@@ -1,0 +1,34 @@
+//
+//  PacketInspectionCoordinatorTests.swift
+//  AXTermTests
+//
+//  Created by Ross Wardrup on 2/1/26.
+//
+
+import XCTest
+@testable import AXTerm
+
+final class PacketInspectionCoordinatorTests: XCTestCase {
+    func testInspectSelectedPacketReturnsSelectionWhenFound() {
+        let id = UUID()
+        let packets = [
+            Packet(id: id, from: AX25Address(call: "N0CALL"))
+        ]
+        let selection: Set<Packet.ID> = [id]
+        let coordinator = PacketInspectionCoordinator()
+
+        let result = coordinator.inspectSelectedPacket(selection: selection, packets: packets)
+
+        XCTAssertEqual(result, PacketInspectorSelection(id: id))
+    }
+
+    func testInspectSelectedPacketReturnsNilWhenMissing() {
+        let packets = [Packet(id: UUID(), from: AX25Address(call: "N0CALL"))]
+        let selection: Set<Packet.ID> = [UUID()]
+        let coordinator = PacketInspectionCoordinator()
+
+        let result = coordinator.inspectSelectedPacket(selection: selection, packets: packets)
+
+        XCTAssertNil(result)
+    }
+}

--- a/AXTermTests/PayloadTokenExtractorTests.swift
+++ b/AXTermTests/PayloadTokenExtractorTests.swift
@@ -1,0 +1,35 @@
+//
+//  PayloadTokenExtractorTests.swift
+//  AXTermTests
+//
+//  Created by Ross Wardrup on 2/1/26.
+//
+
+import XCTest
+@testable import AXTerm
+
+final class PayloadTokenExtractorTests: XCTestCase {
+    func testDetectsCallsignSuffixTokens() {
+        let payload = "KB5YZB/R YZBBPQ/D KB5YZB-1/B KB5YZB-7/N"
+
+        let summary = PayloadTokenExtractor.summarize(text: payload)
+
+        XCTAssertEqual(summary.callsigns, ["KB5YZB/R", "YZBBPQ/D", "KB5YZB-1/B", "KB5YZB-7/N"])
+    }
+
+    func testDoesNotTreatSingleLettersAsCallsigns() {
+        let payload = "R D /R K"
+
+        let summary = PayloadTokenExtractor.summarize(text: payload)
+
+        XCTAssertTrue(summary.callsigns.isEmpty)
+    }
+
+    func testPreservesDigipeaterStar() {
+        let payload = "DRLNOD*"
+
+        let summary = PayloadTokenExtractor.summarize(text: payload)
+
+        XCTAssertEqual(summary.callsigns, ["DRLNOD*"])
+    }
+}


### PR DESCRIPTION
### Motivation
- Repo inspection showed the packet table is implemented in `AXTerm/PacketTableView.swift`, selection and inspector state live in `AXTerm/ContentView.swift` (with `selection` and `inspectorSelection`), the inspector UI is `AXTerm/PacketInspectorView.swift`, JSON export lives in `AXTerm/PacketExport.swift`, token parsing is in `AXTerm/PayloadTokenExtractor.swift`, and unit tests are in `AXTermTests/` (e.g. `PacketSelectionResolverTests.swift`).
- The goal was to make double‑click anywhere on a row open the inspector, add a minimal right‑click menu acting on the clicked row, improve clipboard/JSON UX with lightweight feedback and optional save, and fix detected tokenization for callsigns with suffixes like `/R`, preserving common AX.25 notation.

### Description
- Added a small inspection coordinator `AXTerm/PacketInspectionCoordinator.swift` that provides a single source‑of‑truth `inspectSelectedPacket(selection:packets:)` used by the UI to open the inspector. 
- Reworked the table row plumbing in `AXTerm/PacketTableView.swift` by introducing `PacketTableCell` and `AXTerm/RowSelectionCaptureView.swift` (an `NSViewRepresentable`) so a right‑click selects the row and a row‑wide double‑click/Return/Enter triggers the same `inspectSelectedPacket()` command; the table now exposes handlers `onInspectSelection`, `onCopyInfo`, and `onCopyRawHex` wired from `ContentView`.
- Implemented a minimal HIG‑appropriate context menu on rows with exactly `Inspect Packet (⌘I)`, `Copy Info`, and `Copy Raw Hex` that operate on the row under the cursor and select that row first.
- Centralized pasteboard writes to `AXTerm/ClipboardWriter.swift` and replaced ad-hoc clipboard calls in the inspector and `ContentView` with this helper.
- Updated `AXTerm/PacketInspectorView.swift` to rename the action to `Copy JSON`, provide a `Save JSON…` action using `NSSavePanel`, add deterministic pretty JSON helpers in `PacketExport` (`jsonData()` and `writeJSON(to:)`), and show a short inline transient “Copied” badge next to copy buttons (non‑modal feedback). 
- Fixed token extraction in `AXTerm/PayloadTokenExtractor.swift` by updating the regex to preserve optional `-SSID`, optional `/suffix` (e.g. `/R`, `/D`, `/B`), and optional trailing `*` digipeater marker, and added minimal guards to avoid single‑letter false positives.
- Added unit tests: `AXTermTests/PayloadTokenExtractorTests.swift` (callsign suffix cases and negatives), `AXTermTests/PacketExportTests.swift` (JSON keys and `writeJSON` file output), and `AXTermTests/PacketInspectionCoordinatorTests.swift` (coordinator behavior for selection present/missing).
- Kept changes minimal and localized, avoided forced unwraps, preserved original JSON fields produced by `PacketExport`, and left accessibility/keyboard shortcuts intact via the existing focused value command (`Inspect Packet` / `⌘I`).

### Testing
- New unit tests added: `PayloadTokenExtractorTests`, `PacketExportTests`, and `PacketInspectionCoordinatorTests` under `AXTermTests`; they validate callsign detection, JSON serialization/file write, and the inspection coordinator behavior respectively.
- Attempted to run the test suite with `xcodebuild test -scheme AXTerm -destination 'platform=macOS'`, but `xcodebuild` is not available in this environment so automated tests could not be executed here (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a8b0696208330ab9f866f93ebc4d6)