### PR TITLE
Remove unsupported .enter key handler in PacketTableView

### DIFF
--- a/AXTerm/PacketTableView.swift
+++ b/AXTerm/PacketTableView.swift
@@ -116,10 +116,6 @@ struct PacketTableView: View {
             onInspectSelection()
             return .handled
         }
-        .onKeyPress(.enter) {
-            onInspectSelection()
-            return .handled
-        }
     }
 
     private func rowForeground(_ packet: Packet) -> Color {


### PR DESCRIPTION
### Motivation
- The macOS build failed because the `.enter` key handler is not supported, so the handler was removed to resolve the build error.

### Description
- Deleted the `.onKeyPress(.enter)` handler from `AXTerm/PacketTableView.swift`, keeping the existing `.onKeyPress(.return)` behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a8e1ee13483309e1d486989d0479f)