### PR TITLE
Fix return key handling in packet table

### DIFF
--- a/AXTerm/PacketTableView.swift
+++ b/AXTerm/PacketTableView.swift
@@ -112,10 +112,13 @@ struct PacketTableView: View {
             }
         }
         .focusable(true)
-        .onKeyPress(.return) {
-            onInspectSelection()
-            return .handled
-        }
+        .background(
+            Button(action: onInspectSelection) {
+                EmptyView()
+            }
+            .keyboardShortcut(.defaultAction)
+            .hidden()
+        )
     }
 
     private func rowForeground(_ packet: Packet) -> Color {


### PR DESCRIPTION
### Motivation
- Replace fragile `.onKeyPress(.return)` usage with a standard default-action keyboard shortcut to ensure the Return key triggers inspection reliably and avoid build/runtime issues on platforms where `onKeyPress` is unavailable.

### Description
- Replaced the `.onKeyPress(.return)` handler in `AXTerm/PacketTableView.swift` with a hidden `Button` that calls `onInspectSelection` and uses `.keyboardShortcut(.defaultAction)`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a8eb43a80833092635c60db61639a)