### PR TITLE
Fix Return-key inspect shortcut and add JSON UTType import

### DIFF
--- a/AXTerm/PacketInspectorView.swift
+++ b/AXTerm/PacketInspectorView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import AppKit
+import UniformTypeIdentifiers
 
 struct PacketInspectorView: View {
     let packet: Packet

--- a/AXTerm/PacketTableView.swift
+++ b/AXTerm/PacketTableView.swift
@@ -112,10 +112,13 @@ struct PacketTableView: View {
             }
         }
         .focusable(true)
-        .onKeyPress(.return) {
-            onInspectSelection()
-            return .handled
-        }
+        .background(
+            Button(action: onInspectSelection) {
+                EmptyView()
+            }
+            .keyboardShortcut(.defaultAction)
+            .hidden()
+        )
     }
 
     private func rowForeground(_ packet: Packet) -> Color {


### PR DESCRIPTION
### Motivation
- Ensure the Return key reliably triggers packet inspection by replacing fragile `.onKeyPress(.return)` usage with a standard default-action keyboard shortcut.
- Resolve a build/runtime error when configuring a save panel with the `.json` UTType by making the `UTType` symbol available.

### Description
- Replaced the `.onKeyPress(.return)` handler in `AXTerm/PacketTableView.swift` with a hidden `Button` that invokes `onInspectSelection` and is assigned `.keyboardShortcut(.defaultAction)` so the Return key triggers the action consistently.
- Added `import UniformTypeIdentifiers` to `AXTerm/PacketInspectorView.swift` so the `.json` UTType can be referenced when configuring save panels.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a8eb43a80833092635c60db61639a)