### PR TITLE
Fix onChange deprecation warnings

### DIFF
--- a/AXTerm/ContentView.swift
+++ b/AXTerm/ContentView.swift
@@ -177,15 +177,15 @@ struct ContentView: View {
                 ClipboardWriter.copy(PayloadFormatter.hexString(packet.rawAx25))
             }
         )
-        .onChange(of: selection) { _ in
-            if selection.isEmpty {
+        .onChange(of: selection) { _, newSelection in
+            if newSelection.isEmpty {
                 inspectorSelection = nil
             }
         }
-        .onChange(of: searchText) { _ in syncSelection(with: rows) }
-        .onChange(of: filters) { _ in syncSelection(with: rows) }
-        .onChange(of: client.selectedStationCall) { _ in syncSelection(with: rows) }
-        .onChange(of: client.packets) { _ in syncSelection(with: rows) }
+        .onChange(of: searchText) { _, _ in syncSelection(with: rows) }
+        .onChange(of: filters) { _, _ in syncSelection(with: rows) }
+        .onChange(of: client.selectedStationCall) { _, _ in syncSelection(with: rows) }
+        .onChange(of: client.packets) { _, _ in syncSelection(with: rows) }
     }
 
     // MARK: - Toolbar


### PR DESCRIPTION
### Motivation
- Remove macOS 14 deprecation warnings by adopting the updated `onChange` closure signature.

### Description
- Replace several `.onChange` handlers in `AXTerm/ContentView.swift` to use the newer closure form (for example `.onChange(of: selection) { _, newSelection in ... }` and `.onChange(of: foo) { _, _ in ... }`) so the compiler no longer emits deprecation warnings.

### Testing
- No automated tests were run; this is a small syntactic change to silence compiler warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a905d5f64833090e40bb78bf4349f)