### PR TITLE
Add GRDB-backed SQLite persistence, Settings UI, and persistence integration

### DIFF
--- a/AXTerm.xcodeproj/project.pbxproj
+++ b/AXTerm.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9B1C3E6C2F3A000100000003 /* GRDB in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -59,6 +60,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9B1C3E6C2F3A000100000004 /* GRDB in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -70,6 +72,11 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXBuildFile section */
+		9B1C3E6C2F3A000100000003 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = 9B1C3E6C2F3A000100000002 /* GRDB */; };
+		9B1C3E6C2F3A000100000004 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = 9B1C3E6C2F3A000100000002 /* GRDB */; };
+/* End PBXBuildFile section */
 
 /* Begin PBXGroup section */
 		3487E8942F2AA2A700DF0172 = {
@@ -112,6 +119,7 @@
 			);
 			name = AXTerm;
 			packageProductDependencies = (
+				9B1C3E6C2F3A000100000002 /* GRDB */,
 			);
 			productName = AXTerm;
 			productReference = 3487E89D2F2AA2A700DF0172 /* AXTerm.app */;
@@ -135,6 +143,7 @@
 			);
 			name = AXTermTests;
 			packageProductDependencies = (
+				9B1C3E6C2F3A000100000002 /* GRDB */,
 			);
 			productName = AXTermTests;
 			productReference = 3487E8AA2F2AA2A800DF0172 /* AXTermTests.xctest */;
@@ -199,6 +208,9 @@
 			productRefGroup = 3487E89E2F2AA2A700DF0172 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
+			packageReferences = (
+				9B1C3E6C2F3A000100000001 /* XCRemoteSwiftPackageReference "GRDB.swift" */,
+			);
 			targets = (
 				3487E89C2F2AA2A700DF0172 /* AXTerm */,
 				3487E8A92F2AA2A800DF0172 /* AXTermTests */,
@@ -206,6 +218,25 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		9B1C3E6C2F3A000100000001 /* XCRemoteSwiftPackageReference "GRDB.swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/groue/GRDB.swift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 6.29.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		9B1C3E6C2F3A000100000002 /* GRDB */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9B1C3E6C2F3A000100000001 /* XCRemoteSwiftPackageReference "GRDB.swift" */;
+			productName = GRDB;
+		};
+/* End XCSwiftPackageProductDependency section */
 
 /* Begin PBXResourcesBuildPhase section */
 		3487E89B2F2AA2A700DF0172 /* Resources */ = {

--- a/AXTerm/AXTermApp.swift
+++ b/AXTerm/AXTermApp.swift
@@ -9,9 +9,21 @@ import SwiftUI
 
 @main
 struct AXTermApp: App {
+    @StateObject private var settings: AppSettingsStore
+    private let packetStore: PacketStore?
+    private let client: KISSTcpClient
+
+    init() {
+        let settingsStore = AppSettingsStore()
+        _settings = StateObject(wrappedValue: settingsStore)
+        let store = try? SQLitePacketStore()
+        self.packetStore = store
+        self.client = KISSTcpClient(settings: settingsStore, packetStore: store)
+    }
+
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ContentView(client: client, settings: settings)
         }
         .commands {
             CommandGroup(after: .windowArrangement) {
@@ -21,6 +33,10 @@ struct AXTermApp: App {
                 .keyboardShortcut("w", modifiers: [.command])
             }
             AXTermCommands()
+        }
+
+        Settings {
+            SettingsView(settings: settings, client: client, packetStore: packetStore)
         }
     }
 }

--- a/AXTerm/Packet.swift
+++ b/AXTerm/Packet.swift
@@ -17,6 +17,7 @@ struct Packet: Identifiable, Hashable {
     let to: AX25Address?
     let via: [AX25Address]
     let frameType: FrameType
+    let control: UInt8
     let pid: UInt8?
     let info: Data
     let rawAx25: Data
@@ -89,6 +90,7 @@ struct Packet: Identifiable, Hashable {
         to: AX25Address? = nil,
         via: [AX25Address] = [],
         frameType: FrameType = .unknown,
+        control: UInt8 = 0,
         pid: UInt8? = nil,
         info: Data = Data(),
         rawAx25: Data = Data()
@@ -99,6 +101,7 @@ struct Packet: Identifiable, Hashable {
         self.to = to
         self.via = via
         self.frameType = frameType
+        self.control = control
         self.pid = pid
         self.info = info
         self.rawAx25 = rawAx25

--- a/AXTerm/Persistence/DatabaseManager.swift
+++ b/AXTerm/Persistence/DatabaseManager.swift
@@ -1,0 +1,75 @@
+//
+//  DatabaseManager.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 2/1/26.
+//
+
+import Foundation
+import GRDB
+
+enum DatabaseManager {
+    static let folderName = "AXTerm"
+    static let databaseName = "axterm.sqlite"
+
+    static func databaseURL() throws -> URL {
+        let base = try FileManager.default.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+        let folderURL = base.appendingPathComponent(folderName, isDirectory: true)
+        try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+        return folderURL.appendingPathComponent(databaseName)
+    }
+
+    static func makeDatabaseQueue() throws -> DatabaseQueue {
+        let url = try databaseURL()
+        let queue = try DatabaseQueue(path: url.path)
+        try migrator.migrate(queue)
+        return queue
+    }
+
+    static let migrator: DatabaseMigrator = {
+        var migrator = DatabaseMigrator()
+        migrator.registerMigration("createPackets") { db in
+            try db.create(table: PacketRecord.databaseTableName) { table in
+                table.column("id", .text).primaryKey()
+                table.column("receivedAt", .datetime).notNull()
+                table.column("ax25Timestamp", .datetime)
+                table.column("direction", .text).notNull()
+                table.column("source", .text).notNull()
+                table.column("fromCall", .text).notNull()
+                table.column("fromSSID", .integer).notNull()
+                table.column("toCall", .text).notNull()
+                table.column("toSSID", .integer).notNull()
+                table.column("viaPath", .text).notNull()
+                table.column("viaCount", .integer).notNull()
+                table.column("hasDigipeaters", .boolean).notNull()
+                table.column("frameType", .text).notNull()
+                table.column("controlHex", .text).notNull()
+                table.column("pid", .integer)
+                table.column("infoLen", .integer).notNull()
+                table.column("isPrintableText", .boolean).notNull()
+                table.column("infoText", .text)
+                table.column("infoASCII", .text).notNull()
+                table.column("infoHex", .text).notNull()
+                table.column("rawAx25Hex", .text).notNull()
+                table.column("portName", .text)
+                table.column("pinned", .boolean).notNull().defaults(to: false)
+                table.column("tags", .text)
+            }
+
+            try db.create(index: "idx_packets_receivedAt", on: PacketRecord.databaseTableName, columns: ["receivedAt"])
+            try db.create(index: "idx_packets_from", on: PacketRecord.databaseTableName, columns: ["fromCall", "fromSSID"])
+            try db.create(index: "idx_packets_to", on: PacketRecord.databaseTableName, columns: ["toCall", "toSSID"])
+            try db.create(index: "idx_packets_frameType", on: PacketRecord.databaseTableName, columns: ["frameType"])
+            try db.create(index: "idx_packets_printable", on: PacketRecord.databaseTableName, columns: ["isPrintableText"])
+            try db.create(index: "idx_packets_pinned", on: PacketRecord.databaseTableName, columns: ["pinned"])
+            try db.create(index: "idx_packets_viaCount", on: PacketRecord.databaseTableName, columns: ["viaCount"])
+            try db.create(index: "idx_packets_from_receivedAt", on: PacketRecord.databaseTableName, columns: ["fromCall", "receivedAt"])
+        }
+        return migrator
+    }()
+}

--- a/AXTerm/Persistence/PacketEncoding.swift
+++ b/AXTerm/Persistence/PacketEncoding.swift
@@ -1,0 +1,95 @@
+//
+//  PacketEncoding.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 2/1/26.
+//
+
+import Foundation
+
+enum PacketEncoding {
+    static let printableThreshold: Double = 0.75
+    static let separator: Character = ","
+    static let repeatedMarker: Character = "*"
+
+    static func encodeHex(_ data: Data) -> String {
+        guard !data.isEmpty else { return "" }
+        return data.map { String(format: "%02X", $0) }.joined()
+    }
+
+    static func decodeHex(_ hex: String) -> Data {
+        let cleaned = hex.filter { !$0.isWhitespace }
+        guard cleaned.count % 2 == 0 else { return Data() }
+        var data = Data()
+        data.reserveCapacity(cleaned.count / 2)
+        var index = cleaned.startIndex
+        while index < cleaned.endIndex {
+            let nextIndex = cleaned.index(index, offsetBy: 2)
+            let byteString = cleaned[index..<nextIndex]
+            if let byte = UInt8(byteString, radix: 16) {
+                data.append(byte)
+            } else {
+                return Data()
+            }
+            index = nextIndex
+        }
+        return data
+    }
+
+    static func encodeControl(_ control: UInt8) -> String {
+        String(format: "%02X", control)
+    }
+
+    static func decodeControl(_ hex: String) -> UInt8 {
+        UInt8(hex, radix: 16) ?? 0
+    }
+
+    static func asciiString(_ data: Data) -> String {
+        PayloadFormatter.asciiString(data)
+    }
+
+    static func isPrintableText(_ data: Data) -> Bool {
+        guard !data.isEmpty else { return false }
+        let printableCount = data.filter { $0 >= 0x20 && $0 < 0x7F || $0 == 0x0A || $0 == 0x0D }.count
+        let ratio = Double(printableCount) / Double(data.count)
+        return ratio >= printableThreshold
+    }
+
+    static func encodeViaPath(_ via: [AX25Address]) -> String {
+        guard !via.isEmpty else { return "" }
+        return via.map { address in
+            address.repeated ? "\(address.display)\(repeatedMarker)" : address.display
+        }.joined(separator: String(separator))
+    }
+
+    static func decodeViaPath(_ path: String) -> [AX25Address] {
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+        return trimmed.split(separator: separator).compactMap { token in
+            decodeAddressToken(String(token))
+        }
+    }
+
+    static func decodeAddressToken(_ token: String) -> AX25Address? {
+        let cleaned = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleaned.isEmpty else { return nil }
+        let repeated = cleaned.last == repeatedMarker
+        let base = repeated ? String(cleaned.dropLast()) : cleaned
+        let (call, ssid) = parseCallsign(base)
+        guard !call.isEmpty else { return nil }
+        return AX25Address(call: call, ssid: ssid, repeated: repeated)
+    }
+
+    static func parseCallsign(_ value: String) -> (call: String, ssid: Int) {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return ("", 0) }
+        let parts = trimmed.split(separator: "-", maxSplits: 1, omittingEmptySubsequences: true)
+        let call = String(parts[0]).uppercased()
+        var ssid = 0
+        if parts.count > 1 {
+            ssid = Int(parts[1]) ?? 0
+        }
+        ssid = max(0, min(15, ssid))
+        return (call, ssid)
+    }
+}

--- a/AXTerm/Persistence/PacketRecord.swift
+++ b/AXTerm/Persistence/PacketRecord.swift
@@ -1,0 +1,96 @@
+//
+//  PacketRecord.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 2/1/26.
+//
+
+import Foundation
+import GRDB
+
+struct PacketRecord: Codable, FetchableRecord, PersistableRecord, Hashable {
+    static let databaseTableName = "packets"
+
+    var id: UUID
+    var receivedAt: Date
+    var ax25Timestamp: Date?
+    var direction: String
+    var source: String
+    var fromCall: String
+    var fromSSID: Int
+    var toCall: String
+    var toSSID: Int
+    var viaPath: String
+    var viaCount: Int
+    var hasDigipeaters: Bool
+    var frameType: String
+    var controlHex: String
+    var pid: Int?
+    var infoLen: Int
+    var isPrintableText: Bool
+    var infoText: String?
+    var infoASCII: String
+    var infoHex: String
+    var rawAx25Hex: String
+    var portName: String?
+    var pinned: Bool
+    var tags: String?
+
+    init(packet: Packet) {
+        let from = packet.from ?? AX25Address(call: "UNKNOWN")
+        let to = packet.to ?? AX25Address(call: "UNKNOWN")
+        let viaPath = PacketEncoding.encodeViaPath(packet.via)
+        let infoHex = PacketEncoding.encodeHex(packet.info)
+        let rawHex = PacketEncoding.encodeHex(packet.rawAx25)
+        let infoASCII = PacketEncoding.asciiString(packet.info)
+        let printable = PacketEncoding.isPrintableText(packet.info)
+
+        self.id = packet.id
+        self.receivedAt = packet.timestamp
+        self.ax25Timestamp = nil
+        self.direction = "rx"
+        self.source = "kiss"
+        self.fromCall = from.call
+        self.fromSSID = from.ssid
+        self.toCall = to.call
+        self.toSSID = to.ssid
+        self.viaPath = viaPath
+        self.viaCount = packet.via.count
+        self.hasDigipeaters = !packet.via.isEmpty
+        self.frameType = packet.frameType.rawValue
+        self.controlHex = PacketEncoding.encodeControl(packet.control)
+        self.pid = packet.pid.map { Int($0) }
+        self.infoLen = packet.info.count
+        self.isPrintableText = printable
+        self.infoText = printable ? packet.infoText : nil
+        self.infoASCII = infoASCII
+        self.infoHex = infoHex
+        self.rawAx25Hex = rawHex
+        self.portName = nil
+        self.pinned = false
+        self.tags = nil
+    }
+
+    func toPacket() -> Packet {
+        let from = AX25Address(call: fromCall, ssid: fromSSID)
+        let to = AX25Address(call: toCall, ssid: toSSID)
+        let via = PacketEncoding.decodeViaPath(viaPath)
+        let info = PacketEncoding.decodeHex(infoHex)
+        let raw = PacketEncoding.decodeHex(rawAx25Hex)
+        let frame = FrameType(rawValue: frameType) ?? .unknown
+        let control = PacketEncoding.decodeControl(controlHex)
+        let pidValue = pid.flatMap { UInt8(clamping: $0) }
+        return Packet(
+            id: id,
+            timestamp: receivedAt,
+            from: from,
+            to: to,
+            via: via,
+            frameType: frame,
+            control: control,
+            pid: pidValue,
+            info: info,
+            rawAx25: raw
+        )
+    }
+}

--- a/AXTerm/Persistence/PacketStore.swift
+++ b/AXTerm/Persistence/PacketStore.swift
@@ -1,0 +1,17 @@
+//
+//  PacketStore.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 2/1/26.
+//
+
+import Foundation
+
+protocol PacketStore {
+    func save(_ packet: Packet) throws
+    func loadRecent(limit: Int) throws -> [PacketRecord]
+    func deleteAll() throws
+    func setPinned(packetId: UUID, pinned: Bool) throws
+    func pruneIfNeeded(retentionLimit: Int) throws
+    func count() throws -> Int
+}

--- a/AXTerm/Persistence/SQLitePacketStore.swift
+++ b/AXTerm/Persistence/SQLitePacketStore.swift
@@ -1,0 +1,75 @@
+//
+//  SQLitePacketStore.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 2/1/26.
+//
+
+import Foundation
+import GRDB
+
+final class SQLitePacketStore: PacketStore {
+    private let dbQueue: DatabaseQueue
+
+    init(dbQueue: DatabaseQueue = try DatabaseManager.makeDatabaseQueue()) {
+        self.dbQueue = dbQueue
+    }
+
+    func save(_ packet: Packet) throws {
+        let record = PacketRecord(packet: packet)
+        try dbQueue.write { db in
+            try record.insert(db)
+        }
+    }
+
+    func loadRecent(limit: Int) throws -> [PacketRecord] {
+        try dbQueue.read { db in
+            try PacketRecord
+                .order(Column("receivedAt").desc)
+                .limit(limit)
+                .fetchAll(db)
+        }
+    }
+
+    func deleteAll() throws {
+        try dbQueue.write { db in
+            _ = try PacketRecord.deleteAll(db)
+        }
+    }
+
+    func setPinned(packetId: UUID, pinned: Bool) throws {
+        try dbQueue.write { db in
+            try db.execute(
+                sql: "UPDATE \(PacketRecord.databaseTableName) SET pinned = ? WHERE id = ?",
+                arguments: [pinned, packetId.uuidString]
+            )
+        }
+    }
+
+    func pruneIfNeeded(retentionLimit: Int) throws {
+        guard retentionLimit > 0 else { return }
+        try dbQueue.write { db in
+            let total = try PacketRecord.fetchCount(db)
+            guard total > retentionLimit else { return }
+            let overflow = total - retentionLimit
+            if overflow <= 0 { return }
+            try db.execute(
+                sql: """
+                DELETE FROM \(PacketRecord.databaseTableName)
+                WHERE id IN (
+                    SELECT id FROM \(PacketRecord.databaseTableName)
+                    ORDER BY receivedAt ASC
+                    LIMIT ?
+                )
+                """,
+                arguments: [overflow]
+            )
+        }
+    }
+
+    func count() throws -> Int {
+        try dbQueue.read { db in
+            try PacketRecord.fetchCount(db)
+        }
+    }
+}

--- a/AXTerm/Settings/AppSettingsStore.swift
+++ b/AXTerm/Settings/AppSettingsStore.swift
@@ -1,0 +1,110 @@
+//
+//  AppSettingsStore.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 2/1/26.
+//
+
+import Foundation
+import Combine
+
+final class AppSettingsStore: ObservableObject {
+    static let hostKey = "lastHost"
+    static let portKey = "lastPort"
+    static let retentionKey = "retentionLimit"
+    static let persistKey = "persistHistory"
+
+    static let defaultHost = "localhost"
+    static let defaultPort = 8001
+    static let defaultRetention = 50_000
+    static let minRetention = 1_000
+    static let maxRetention = 500_000
+
+    @Published var host: String {
+        didSet {
+            let sanitized = Self.sanitizeHost(host)
+            guard sanitized == host else {
+                host = sanitized
+                return
+            }
+            persistHost()
+        }
+    }
+
+    @Published var port: String {
+        didSet {
+            let sanitized = Self.sanitizePort(port)
+            guard sanitized == port else {
+                port = sanitized
+                return
+            }
+            persistPort()
+        }
+    }
+
+    @Published var retentionLimit: Int {
+        didSet {
+            let sanitized = Self.sanitizeRetention(retentionLimit)
+            guard sanitized == retentionLimit else {
+                retentionLimit = sanitized
+                return
+            }
+            persistRetention()
+        }
+    }
+
+    @Published var persistHistory: Bool {
+        didSet { persistPersistHistory() }
+    }
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        let storedHost = defaults.string(forKey: Self.hostKey) ?? Self.defaultHost
+        let storedPort = defaults.string(forKey: Self.portKey) ?? String(Self.defaultPort)
+        let storedRetention = defaults.object(forKey: Self.retentionKey) as? Int ?? Self.defaultRetention
+        let storedPersist = defaults.object(forKey: Self.persistKey) as? Bool ?? true
+
+        self.host = Self.sanitizeHost(storedHost)
+        self.port = Self.sanitizePort(storedPort)
+        self.retentionLimit = Self.sanitizeRetention(storedRetention)
+        self.persistHistory = storedPersist
+    }
+
+    var portValue: UInt16 {
+        UInt16(Self.sanitizePort(port)) ?? UInt16(Self.defaultPort)
+    }
+
+    static func sanitizeHost(_ value: String) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? defaultHost : trimmed
+    }
+
+    static func sanitizePort(_ value: String) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let portValue = Int(trimmed) else { return String(defaultPort) }
+        let clamped = min(max(portValue, 1), 65_535)
+        return String(clamped)
+    }
+
+    static func sanitizeRetention(_ value: Int) -> Int {
+        min(max(value, minRetention), maxRetention)
+    }
+
+    private func persistHost() {
+        defaults.set(host, forKey: Self.hostKey)
+    }
+
+    private func persistPort() {
+        defaults.set(port, forKey: Self.portKey)
+    }
+
+    private func persistRetention() {
+        defaults.set(retentionLimit, forKey: Self.retentionKey)
+    }
+
+    private func persistPersistHistory() {
+        defaults.set(persistHistory, forKey: Self.persistKey)
+    }
+}

--- a/AXTerm/Settings/SettingsView.swift
+++ b/AXTerm/Settings/SettingsView.swift
@@ -1,0 +1,138 @@
+//
+//  SettingsView.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 2/1/26.
+//
+
+import SwiftUI
+
+struct SettingsView: View {
+    @ObservedObject var settings: AppSettingsStore
+    @ObservedObject var client: KISSTcpClient
+    let packetStore: PacketStore?
+
+    @State private var showingClearConfirmation = false
+    @State private var clearFeedback: String?
+
+    private let retentionStep = 1_000
+
+    var body: some View {
+        Form {
+            Section("Connection") {
+                TextField("KISS Host", text: $settings.host)
+                    .textFieldStyle(.roundedBorder)
+
+                TextField("KISS Port", text: $settings.port)
+                    .textFieldStyle(.roundedBorder)
+
+                if shouldSuggestReconnect {
+                    Text("Reconnect to apply host/port changes.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Section("History") {
+                Toggle("Persist history", isOn: $settings.persistHistory)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text("Retention limit")
+                        Spacer()
+                        Text("\(settings.retentionLimit) packets")
+                            .foregroundStyle(.secondary)
+                    }
+
+                    HStack(spacing: 8) {
+                        TextField(
+                            "",
+                            value: $settings.retentionLimit,
+                            format: .number
+                        )
+                        .frame(width: 80)
+                        .textFieldStyle(.roundedBorder)
+                        .accessibilityLabel("Retention limit")
+
+                        Stepper(
+                            "",
+                            value: $settings.retentionLimit,
+                            in: AppSettingsStore.minRetention...AppSettingsStore.maxRetention,
+                            step: retentionStep
+                        )
+                        .labelsHidden()
+                    }
+
+                    Text("Adjust how many packets are retained on disk. Older packets are pruned in the background.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .disabled(!settings.persistHistory)
+
+                HStack {
+                    Button("Clear History…") {
+                        showingClearConfirmation = true
+                    }
+
+                    if let feedback = clearFeedback {
+                        Text(feedback)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .padding(20)
+        .confirmationDialog(
+            "Clear all stored packet history?",
+            isPresented: $showingClearConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Clear History", role: .destructive) {
+                clearHistory()
+            }
+        } message: {
+            Text("This removes all persisted packets. Live packets will continue to appear.")
+        }
+    }
+
+    private var shouldSuggestReconnect: Bool {
+        guard client.status == .connected else { return false }
+        if let connectedHost = client.connectedHost, connectedHost != settings.host {
+            return true
+        }
+        if let connectedPort = client.connectedPort, connectedPort != settings.portValue {
+            return true
+        }
+        return false
+    }
+
+    private func clearHistory() {
+        clearFeedback = nil
+        DispatchQueue.global(qos: .utility).async { [packetStore] in
+            do {
+                try packetStore?.deleteAll()
+            } catch {
+                return
+            }
+            DispatchQueue.main.async {
+                client.clearPackets()
+                client.clearStations()
+                clearFeedback = "Cleared"
+                Task { @MainActor in
+                    try? await Task.sleep(nanoseconds: 1_500_000_000)
+                    clearFeedback = nil
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    SettingsView(
+        settings: AppSettingsStore(),
+        client: KISSTcpClient(settings: AppSettingsStore()),
+        packetStore: nil
+    )
+}

--- a/AXTermTests/AppSettingsStoreTests.swift
+++ b/AXTermTests/AppSettingsStoreTests.swift
@@ -1,0 +1,29 @@
+//
+//  AppSettingsStoreTests.swift
+//  AXTermTests
+//
+//  Created by Ross Wardrup on 2/1/26.
+//
+
+import XCTest
+@testable import AXTerm
+
+final class AppSettingsStoreTests: XCTestCase {
+    func testHostValidationDefaultsToLocalhost() {
+        XCTAssertEqual(AppSettingsStore.sanitizeHost("   "), AppSettingsStore.defaultHost)
+        XCTAssertEqual(AppSettingsStore.sanitizeHost("kiss.local"), "kiss.local")
+    }
+
+    func testPortValidationClampsToRange() {
+        XCTAssertEqual(AppSettingsStore.sanitizePort("0"), "1")
+        XCTAssertEqual(AppSettingsStore.sanitizePort("99999"), "65535")
+        XCTAssertEqual(AppSettingsStore.sanitizePort("8001"), "8001")
+        XCTAssertEqual(AppSettingsStore.sanitizePort("abc"), "\(AppSettingsStore.defaultPort)")
+    }
+
+    func testRetentionValidationClamps() {
+        XCTAssertEqual(AppSettingsStore.sanitizeRetention(10), AppSettingsStore.minRetention)
+        XCTAssertEqual(AppSettingsStore.sanitizeRetention(600_000), AppSettingsStore.maxRetention)
+        XCTAssertEqual(AppSettingsStore.sanitizeRetention(50_000), 50_000)
+    }
+}

--- a/AXTermTests/MockPacketStore.swift
+++ b/AXTermTests/MockPacketStore.swift
@@ -1,0 +1,41 @@
+//
+//  MockPacketStore.swift
+//  AXTermTests
+//
+//  Created by Ross Wardrup on 2/1/26.
+//
+
+import Foundation
+@testable import AXTerm
+
+final class MockPacketStore: PacketStore {
+    private(set) var savedPackets: [Packet] = []
+    private(set) var pinnedUpdates: [(UUID, Bool)] = []
+    private(set) var deleteAllCalled = false
+    private(set) var pruneCalls: [Int] = []
+    var loadResult: [PacketRecord] = []
+
+    func save(_ packet: Packet) throws {
+        savedPackets.append(packet)
+    }
+
+    func loadRecent(limit: Int) throws -> [PacketRecord] {
+        Array(loadResult.prefix(limit))
+    }
+
+    func deleteAll() throws {
+        deleteAllCalled = true
+    }
+
+    func setPinned(packetId: UUID, pinned: Bool) throws {
+        pinnedUpdates.append((packetId, pinned))
+    }
+
+    func pruneIfNeeded(retentionLimit: Int) throws {
+        pruneCalls.append(retentionLimit)
+    }
+
+    func count() throws -> Int {
+        savedPackets.count
+    }
+}

--- a/AXTermTests/PacketEncodingTests.swift
+++ b/AXTermTests/PacketEncodingTests.swift
@@ -1,0 +1,50 @@
+//
+//  PacketEncodingTests.swift
+//  AXTermTests
+//
+//  Created by Ross Wardrup on 2/1/26.
+//
+
+import XCTest
+@testable import AXTerm
+
+final class PacketEncodingTests: XCTestCase {
+    func testViaPathRoundTripWithRepeatMarker() {
+        let path = [
+            AX25Address(call: "DRLNOD"),
+            AX25Address(call: "WIDE1", ssid: 1, repeated: true)
+        ]
+        let encoded = PacketEncoding.encodeViaPath(path)
+        XCTAssertEqual(encoded, "DRLNOD,WIDE1-1*")
+
+        let decoded = PacketEncoding.decodeViaPath(encoded)
+        XCTAssertEqual(decoded.count, 2)
+        XCTAssertEqual(decoded[0].display, "DRLNOD")
+        XCTAssertEqual(decoded[1].display, "WIDE1-1")
+        XCTAssertTrue(decoded[1].repeated)
+    }
+
+    func testInfoASCIIRenderingIsDeterministic() {
+        let data = Data([0x41, 0x00, 0x7F, 0x42])
+        XCTAssertEqual(PacketEncoding.asciiString(data), "A··B")
+    }
+
+    func testHexEncodingDeterministic() {
+        let data = Data([0x01, 0xAB, 0x00, 0xFF])
+        XCTAssertEqual(PacketEncoding.encodeHex(data), "01AB00FF")
+    }
+
+    func testSSIDParsingNormalizesCalls() {
+        let parsed = PacketEncoding.parseCallsign("KB5YZB-7")
+        XCTAssertEqual(parsed.call, "KB5YZB")
+        XCTAssertEqual(parsed.ssid, 7)
+
+        let noSSID = PacketEncoding.parseCallsign("ID")
+        XCTAssertEqual(noSSID.call, "ID")
+        XCTAssertEqual(noSSID.ssid, 0)
+
+        let clamped = PacketEncoding.parseCallsign("CALL-15")
+        XCTAssertEqual(clamped.call, "CALL")
+        XCTAssertEqual(clamped.ssid, 15)
+    }
+}

--- a/AXTermTests/PacketHandlingTests.swift
+++ b/AXTermTests/PacketHandlingTests.swift
@@ -1,0 +1,74 @@
+//
+//  PacketHandlingTests.swift
+//  AXTermTests
+//
+//  Created by Ross Wardrup on 2/1/26.
+//
+
+import XCTest
+@testable import AXTerm
+
+@MainActor
+final class PacketHandlingTests: XCTestCase {
+    func testHandleIncomingPacketPersistsWhenEnabled() async {
+        let settings = makeSettings(persistHistory: true)
+        let store = MockPacketStore()
+        let client = KISSTcpClient(maxPackets: 10, maxConsoleLines: 10, maxRawChunks: 10, settings: settings, packetStore: store)
+
+        let packet = Packet(
+            timestamp: Date(),
+            from: AX25Address(call: "N0CALL"),
+            to: AX25Address(call: "DEST"),
+            frameType: .ui,
+            control: 0x03,
+            info: Data([0x41]),
+            rawAx25: Data([0x01])
+        )
+
+        client.handleIncomingPacket(packet)
+
+        XCTAssertEqual(client.packets.count, 1)
+        XCTAssertEqual(client.stations.count, 1)
+
+        await waitForStore(store)
+        XCTAssertEqual(store.savedPackets.count, 1)
+    }
+
+    func testHandleIncomingPacketSkipsPersistenceWhenDisabled() async {
+        let settings = makeSettings(persistHistory: false)
+        let store = MockPacketStore()
+        let client = KISSTcpClient(maxPackets: 10, maxConsoleLines: 10, maxRawChunks: 10, settings: settings, packetStore: store)
+
+        let packet = Packet(
+            timestamp: Date(),
+            from: AX25Address(call: "N0CALL"),
+            to: AX25Address(call: "DEST"),
+            frameType: .ui,
+            control: 0x03,
+            info: Data([0x41]),
+            rawAx25: Data([0x01])
+        )
+
+        client.handleIncomingPacket(packet)
+
+        XCTAssertEqual(client.packets.count, 1)
+        await waitForStore(store)
+        XCTAssertEqual(store.savedPackets.count, 0)
+    }
+
+    private func makeSettings(persistHistory: Bool) -> AppSettingsStore {
+        let suiteName = "AXTermTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName) ?? .standard
+        defaults.set(persistHistory, forKey: AppSettingsStore.persistKey)
+        return AppSettingsStore(defaults: defaults)
+    }
+
+    private func waitForStore(_ store: MockPacketStore) async {
+        for _ in 0..<10 {
+            if !store.savedPackets.isEmpty || !store.pruneCalls.isEmpty {
+                return
+            }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+    }
+}

--- a/AXTermTests/SQLitePacketStoreTests.swift
+++ b/AXTermTests/SQLitePacketStoreTests.swift
@@ -1,0 +1,91 @@
+//
+//  SQLitePacketStoreTests.swift
+//  AXTermTests
+//
+//  Created by Ross Wardrup on 2/1/26.
+//
+
+import XCTest
+import GRDB
+@testable import AXTerm
+
+final class SQLitePacketStoreTests: XCTestCase {
+    func testRoundTripOrderingAndPinned() throws {
+        let store = try makeStore()
+        let first = Packet(
+            timestamp: Date(timeIntervalSince1970: 10),
+            from: AX25Address(call: "CALL1"),
+            to: AX25Address(call: "DEST"),
+            frameType: .ui,
+            control: 0x03,
+            info: Data([0x41]),
+            rawAx25: Data([0x01])
+        )
+        let second = Packet(
+            timestamp: Date(timeIntervalSince1970: 20),
+            from: AX25Address(call: "CALL2"),
+            to: AX25Address(call: "DEST"),
+            frameType: .i,
+            control: 0x00,
+            info: Data([0x42]),
+            rawAx25: Data([0x02])
+        )
+        try store.save(first)
+        try store.save(second)
+        try store.setPinned(packetId: second.id, pinned: true)
+
+        let recent = try store.loadRecent(limit: 10)
+        XCTAssertEqual(recent.map(\.id), [second.id, first.id])
+        XCTAssertEqual(recent.first?.pinned, true)
+    }
+
+    func testPruneRemovesOldest() throws {
+        let store = try makeStore()
+        let packets = (0..<6).map { index in
+            Packet(
+                timestamp: Date(timeIntervalSince1970: TimeInterval(index)),
+                from: AX25Address(call: "CALL\(index)"),
+                to: AX25Address(call: "DEST"),
+                frameType: .u,
+                control: 0x13,
+                info: Data([UInt8(index)]),
+                rawAx25: Data([UInt8(index)])
+            )
+        }
+        for packet in packets {
+            try store.save(packet)
+        }
+        try store.pruneIfNeeded(retentionLimit: 3)
+        let remaining = try store.loadRecent(limit: 10)
+        XCTAssertEqual(remaining.count, 3)
+        XCTAssertFalse(remaining.contains(where: { $0.id == packets[0].id }))
+        XCTAssertTrue(remaining.contains(where: { $0.id == packets[5].id }))
+    }
+
+    func testPersistsAllFrameTypes() throws {
+        let store = try makeStore()
+        let frames: [FrameType] = [.ui, .i, .s, .u]
+        for frame in frames {
+            let packet = Packet(
+                timestamp: Date(),
+                from: AX25Address(call: "CALL"),
+                to: AX25Address(call: "DEST"),
+                frameType: frame,
+                control: 0x03,
+                info: Data([0x41]),
+                rawAx25: Data([0x01])
+            )
+            try store.save(packet)
+        }
+
+        let records = try store.loadRecent(limit: 10)
+        let types = Set(records.map(\.frameType))
+        XCTAssertEqual(types, Set(frames.map(\.rawValue)))
+    }
+
+    private func makeStore() throws -> SQLitePacketStore {
+        let queue = try DatabaseQueue(path: ":memory:")
+        try DatabaseManager.migrator.migrate(queue)
+        return SQLitePacketStore(dbQueue: queue)
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide robust local persistence so AXTerm restores packet history on relaunch and supports analytics without re-decoding raw bytes. 
- Store a normalized, analytics-friendly event log (all KISS/AX.25 frames) so future charts/statistics can be derived from the DB. 
- Expose standard macOS Settings for KISS host/port, retention and history controls and make retention/prune behavior controllable and non-blocking.

### Description
- Added a persistence layer under `Persistence/`: `PacketRecord`, `PacketEncoding` (deterministic encoders for hex/ASCII/via paths), `PacketStore` protocol, `SQLitePacketStore` (GRDB-backed), and `DatabaseManager` with an Application Support DB location and `DatabaseMigrator` schema for `packets` including indexes required for analytics. 
- Introduced settings model and UI: `AppSettingsStore` (typed settings + validation) and `SettingsView` wired into the app `Settings` scene; supports `host`, `port`, `retentionLimit`, `persistHistory` toggle and `Clear History…` with confirmation and subtle feedback. 
- Integrated persistence with the receive pipeline: added `control` to `Packet`, created `handleIncomingPacket(_:)` in `KISSTcpClient` which updates in-memory arrays, MHeard (`StationTracker`), app console lines and persists via injected `PacketStore`; added background pruning and pinned updates, `loadPersistedPackets()` on startup, and `observeSettings()` to react to retention/persist toggles. 
- Project wiring: added GRDB SPM reference to the Xcode project and updated app entry `AXTermApp` to construct `AppSettingsStore`, optional `SQLitePacketStore`, and pass them to `KISSTcpClient` and `ContentView`.

### Testing
- Added unit tests (XCTest) covering deterministic encoding and SSID parsing (`PacketEncodingTests`), the GRDB-backed store round-trip/ordering/pin/prune logic using an in-memory DB (`SQLitePacketStoreTests`), settings validation (`AppSettingsStoreTests`), and receive-path integration with a `MockPacketStore` (`PacketHandlingTests`). All tests are designed as unit tests (no SwiftUI rendering). 
- Tests use an in-memory `DatabaseQueue` for DB tests and dependency injection (`MockPacketStore`) for client tests. 
- Automated test run could not be executed in this environment because `xcodebuild` is not available here, so tests were added but not run; they should be executable locally or in CI (`xcodebuild test -scheme AXTerm -destination 'platform=macOS'`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a915bf09c8330857a5c616300cb00)