### PR TITLE
Fix throwing SQLitePacketStore initializer

### DIFF
--- a/AXTerm/Persistence/SQLitePacketStore.swift
+++ b/AXTerm/Persistence/SQLitePacketStore.swift
@@ -11,8 +11,12 @@ import GRDB
 final class SQLitePacketStore: PacketStore {
     private let dbQueue: DatabaseQueue
 
-    init(dbQueue: DatabaseQueue = try DatabaseManager.makeDatabaseQueue()) {
+    init(dbQueue: DatabaseQueue) {
         self.dbQueue = dbQueue
+    }
+
+    convenience init() throws {
+        try self.init(dbQueue: DatabaseManager.makeDatabaseQueue())
     }
 
     func save(_ packet: Packet) throws {


### PR DESCRIPTION
### Motivation
- Resolve the compiler error and warning caused by using a throwing expression as a default parameter value and make creating a default store explicit and safe.

### Description
- Replace the throwing default parameter on `init(dbQueue:)` with a non-throwing `init(dbQueue: DatabaseQueue)` and add a `convenience init() throws` that calls `DatabaseManager.makeDatabaseQueue()`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a9669084c8330b9dfbce5a1aed343)