### PR TITLE
Persist raw payload BLOBs and KISS endpoint; add indexes/views

### DIFF
--- a/AXTerm/KISSTcpClient.swift
+++ b/AXTerm/KISSTcpClient.swift
@@ -229,6 +229,10 @@ final class KISSTcpClient: ObservableObject {
             return
         }
 
+        let host = connectedHost ?? settings.host
+        let port = connectedPort ?? settings.portValue
+        let endpoint = KISSEndpoint(host: host, port: port)
+
         let packet = Packet(
             timestamp: Date(),
             from: decoded.from,
@@ -238,7 +242,8 @@ final class KISSTcpClient: ObservableObject {
             control: decoded.control,
             pid: decoded.pid,
             info: decoded.info,
-            rawAx25: ax25Data
+            rawAx25: ax25Data,
+            kissEndpoint: endpoint
         )
 
         handleIncomingPacket(packet)

--- a/AXTerm/Packet.swift
+++ b/AXTerm/Packet.swift
@@ -21,6 +21,7 @@ struct Packet: Identifiable, Hashable {
     let pid: UInt8?
     let info: Data
     let rawAx25: Data
+    let kissEndpoint: KISSEndpoint?
 
     /// Info field as text if mostly printable ASCII
     var infoText: String? {
@@ -93,7 +94,8 @@ struct Packet: Identifiable, Hashable {
         control: UInt8 = 0,
         pid: UInt8? = nil,
         info: Data = Data(),
-        rawAx25: Data = Data()
+        rawAx25: Data = Data(),
+        kissEndpoint: KISSEndpoint? = nil
     ) {
         self.id = id
         self.timestamp = timestamp
@@ -105,5 +107,18 @@ struct Packet: Identifiable, Hashable {
         self.pid = pid
         self.info = info
         self.rawAx25 = rawAx25
+        self.kissEndpoint = kissEndpoint
+    }
+}
+
+struct KISSEndpoint: Hashable {
+    let host: String
+    let port: UInt16
+
+    init?(host: String, port: UInt16) {
+        let trimmed = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, port >= 1 else { return nil }
+        self.host = trimmed
+        self.port = port
     }
 }

--- a/AXTerm/Persistence/PacketEncoding.swift
+++ b/AXTerm/Persistence/PacketEncoding.swift
@@ -17,6 +17,10 @@ enum PacketEncoding {
         return data.map { String(format: "%02X", $0) }.joined()
     }
 
+    static func hexString(_ data: Data, bytesPerLine: Int = PayloadFormatter.defaultBytesPerLine) -> String {
+        PayloadFormatter.hexString(data, bytesPerLine: bytesPerLine)
+    }
+
     static func decodeHex(_ hex: String) -> Data {
         let cleaned = hex.filter { !$0.isWhitespace }
         guard cleaned.count % 2 == 0 else { return Data() }

--- a/AXTerm/Persistence/SQLitePacketStore.swift
+++ b/AXTerm/Persistence/SQLitePacketStore.swift
@@ -20,7 +20,10 @@ final class SQLitePacketStore: PacketStore {
     }
 
     func save(_ packet: Packet) throws {
-        let record = PacketRecord(packet: packet)
+        guard let endpoint = packet.kissEndpoint else {
+            throw PacketStoreError.missingKISSEndpoint
+        }
+        let record = try PacketRecord(packet: packet, endpoint: endpoint)
         try dbQueue.write { db in
             try record.insert(db)
         }
@@ -76,4 +79,8 @@ final class SQLitePacketStore: PacketStore {
             try PacketRecord.fetchCount(db)
         }
     }
+}
+
+enum PacketStoreError: Error {
+    case missingKISSEndpoint
 }

--- a/AXTermTests/PacketEncodingTests.swift
+++ b/AXTermTests/PacketEncodingTests.swift
@@ -34,6 +34,11 @@ final class PacketEncodingTests: XCTestCase {
         XCTAssertEqual(PacketEncoding.encodeHex(data), "01AB00FF")
     }
 
+    func testHexDisplayStringDeterministic() {
+        let data = Data([0x01, 0x02, 0x03, 0x04])
+        XCTAssertEqual(PacketEncoding.hexString(data, bytesPerLine: 2), "01 02\n03 04")
+    }
+
     func testSSIDParsingNormalizesCalls() {
         let parsed = PacketEncoding.parseCallsign("KB5YZB-7")
         XCTAssertEqual(parsed.call, "KB5YZB")


### PR DESCRIPTION
### Motivation
- Make stored packets authoritative by persisting raw AX.25 bytes and info bytes as BLOBs so future decoding/analytics uses the exact bytes. 
- Record which KISS TCP endpoint produced each packet so per-endpoint filtering/analytics are possible. 
- Provide deterministic formatting utilities for stable hex/ASCII views and add indexes/views to support future station/time aggregation. 

### Description
- Add `KISSEndpoint` to the in-memory `Packet` and attach the current connection endpoint when frames are produced in `KISSTcpClient`. 
- Extend `PacketRecord` to include BLOB columns `rawAx25Bytes` and `infoBytes` and endpoint columns `kissHost` and `kissPort`, validate endpoint on create, and prefer BLOBs when reconstructing a `Packet`. 
- Update `DatabaseManager` initial migration to create the new columns, analytics-friendly indexes (e.g. `fromCall,fromSSID,receivedAt`, `toCall,toSSID,receivedAt`, `frameType`, `pid`, `isPrintableText`, `pinned`, `viaCount`, `hasDigipeaters`, `kissHost,kissPort`, and composite indexes for common filters) and lightweight views `v_daily_counts` and `v_station_counts`. 
- Add a deterministic `PacketEncoding.hexString` wrapper to use `PayloadFormatter.hexString` and reuse existing `PayloadFormatter.asciiString` for stable ASCII rendering. 
- Require an endpoint when saving in `SQLitePacketStore` and create `PacketRecord` with `rawAx25Bytes`/`infoBytes`; add small error types (`PacketStoreError`, `PacketRecordError`, `DatabaseManagerError`). 
- Implement a DEBUG-only dev-reset: if the on-disk schema is missing required columns, the DB file is deleted and recreated in `DEBUG`, while in Release the code logs and fails with a `schemaMismatch` error. 
- Threaded unit-test updates to cover the new behavior and mapping: `PacketEncodingTests` adds a `hexString` display test and `SQLitePacketStoreTests` now exercise blob round-trip and endpoint persistence. 

### Testing
- Updated unit tests: `PacketEncodingTests` (added `testHexDisplayStringDeterministic`) and `SQLitePacketStoreTests` (adapted existing tests to supply a `KISSEndpoint` and added `testPersistsBlobPayloadsAndEndpoint`). 
- No automated test suite was executed as part of this change in the rollout (tests were updated but not run here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a9900a55c8330b790fe72e2c9f7ef)