### PR TITLE
Persist console/raw history, add diagnostics event log, and day separators

### DIFF
--- a/AXTerm/AXTermApp.swift
+++ b/AXTerm/AXTermApp.swift
@@ -11,14 +11,33 @@ import SwiftUI
 struct AXTermApp: App {
     @StateObject private var settings: AppSettingsStore
     private let packetStore: PacketStore?
+    private let consoleStore: ConsoleStore?
+    private let rawStore: RawStore?
+    private let eventStore: EventLogStore?
+    private let eventLogger: EventLogger?
     private let client: KISSTcpClient
 
     init() {
         let settingsStore = AppSettingsStore()
         _settings = StateObject(wrappedValue: settingsStore)
-        let store = try? SQLitePacketStore()
-        self.packetStore = store
-        self.client = KISSTcpClient(settings: settingsStore, packetStore: store)
+        let queue = try? DatabaseManager.makeDatabaseQueue()
+        let packetStore = queue.map { SQLitePacketStore(dbQueue: $0) }
+        let consoleStore = queue.map { SQLiteConsoleStore(dbQueue: $0) }
+        let rawStore = queue.map { SQLiteRawStore(dbQueue: $0) }
+        let eventStore = queue.map { SQLiteEventLogStore(dbQueue: $0) }
+        let eventLogger = eventStore.map { DatabaseEventLogger(store: $0, settings: settingsStore) }
+        self.packetStore = packetStore
+        self.consoleStore = consoleStore
+        self.rawStore = rawStore
+        self.eventStore = eventStore
+        self.eventLogger = eventLogger
+        self.client = KISSTcpClient(
+            settings: settingsStore,
+            packetStore: packetStore,
+            consoleStore: consoleStore,
+            rawStore: rawStore,
+            eventLogger: eventLogger
+        )
     }
 
     var body: some Scene {
@@ -36,7 +55,18 @@ struct AXTermApp: App {
         }
 
         Settings {
-            SettingsView(settings: settings, client: client, packetStore: packetStore)
+            SettingsView(
+                settings: settings,
+                client: client,
+                packetStore: packetStore,
+                consoleStore: consoleStore,
+                rawStore: rawStore,
+                eventLogger: eventLogger
+            )
+        }
+
+        Window("Diagnostics", id: "diagnostics") {
+            DiagnosticsView(settings: settings, eventStore: eventStore)
         }
     }
 }

--- a/AXTerm/AXTermCommands.swift
+++ b/AXTerm/AXTermCommands.swift
@@ -70,6 +70,7 @@ struct AXTermCommands: Commands {
     @FocusedValue(\.toggleConnection) private var toggleConnection
     @FocusedValue(\.inspectPacket) private var inspectPacket
     @FocusedValue(\.selectNavigation) private var selectNavigation
+    @Environment(\.openWindow) private var openWindow
 
     var body: some Commands {
         CommandGroup(after: .textEditing) {
@@ -106,6 +107,12 @@ struct AXTermCommands: Commands {
                 selectNavigation?.action(.raw)
             }
             .keyboardShortcut("3", modifiers: [.command])
+        }
+
+        CommandGroup(after: .help) {
+            Button("Diagnostics…") {
+                openWindow(id: "diagnostics")
+            }
         }
 
     }

--- a/AXTerm/ConsoleView.swift
+++ b/AXTerm/ConsoleView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct ConsoleView: View {
     let lines: [ConsoleLine]
+    let showDaySeparators: Bool
     let onClear: () -> Void
 
     @State private var autoScroll = true
@@ -40,9 +41,21 @@ struct ConsoleView: View {
             ScrollViewReader { proxy in
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 4) {
-                        ForEach(lines) { line in
-                            ConsoleLineView(line: line)
-                                .id(line.id)
+                        if showDaySeparators {
+                            ForEach(groupedLines) { section in
+                                DaySeparatorView(date: section.date)
+                                    .padding(.vertical, 4)
+
+                                ForEach(section.items) { line in
+                                    ConsoleLineView(line: line)
+                                        .id(line.id)
+                                }
+                            }
+                        } else {
+                            ForEach(lines) { line in
+                                ConsoleLineView(line: line)
+                                    .id(line.id)
+                            }
                         }
                     }
                     .padding()
@@ -58,6 +71,10 @@ struct ConsoleView: View {
             }
             .background(.background)
         }
+    }
+
+    private var groupedLines: [DayGroupedSection<ConsoleLine>] {
+        DayGrouping.group(items: lines, date: { $0.timestamp })
     }
 }
 

--- a/AXTerm/ContentView.swift
+++ b/AXTerm/ContentView.swift
@@ -64,7 +64,7 @@ struct ContentView: View {
         .task {
             guard !didLoadHistory else { return }
             didLoadHistory = true
-            client.loadPersistedPackets()
+            client.loadPersistedHistory()
         }
         .focusedValue(\.searchFocus, SearchFocusAction { isSearchFocused = true })
         .focusedValue(\.toggleConnection, ToggleConnectionAction { toggleConnection() })
@@ -156,9 +156,17 @@ struct ContentView: View {
             case .packets:
                 packetsView
             case .console:
-                ConsoleView(lines: client.consoleLines, onClear: { client.clearConsole() })
+                ConsoleView(
+                    lines: client.consoleLines,
+                    showDaySeparators: settings.showConsoleDaySeparators,
+                    onClear: { client.clearConsole() }
+                )
             case .raw:
-                RawView(chunks: client.rawChunks, onClear: { client.clearRaw() })
+                RawView(
+                    chunks: client.rawChunks,
+                    showDaySeparators: settings.showRawDaySeparators,
+                    onClear: { client.clearRaw() }
+                )
             }
         }
     }

--- a/AXTerm/DayGrouping.swift
+++ b/AXTerm/DayGrouping.swift
@@ -1,0 +1,85 @@
+//
+//  DayGrouping.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 2/2/26.
+//
+
+import Foundation
+import SwiftUI
+
+struct DayGroupedSection<Item: Identifiable>: Identifiable {
+    let id: String
+    let date: Date
+    let items: [Item]
+}
+
+enum DayGrouping {
+    static func group<Item: Identifiable>(
+        items: [Item],
+        date: (Item) -> Date,
+        calendar: Calendar = .current
+    ) -> [DayGroupedSection<Item>] {
+        guard !items.isEmpty else { return [] }
+        var sections: [DayGroupedSection<Item>] = []
+        var currentDate = date(items[0])
+        var currentItems: [Item] = []
+
+        func flushSection() {
+            let id = dayKey(for: currentDate, calendar: calendar)
+            sections.append(DayGroupedSection(id: id, date: currentDate, items: currentItems))
+        }
+
+        for item in items {
+            let itemDate = date(item)
+            if calendar.isDate(itemDate, inSameDayAs: currentDate) {
+                currentItems.append(item)
+            } else {
+                flushSection()
+                currentDate = itemDate
+                currentItems = [item]
+            }
+        }
+        flushSection()
+        return sections
+    }
+
+    static func dayKey(for date: Date, calendar: Calendar) -> String {
+        let start = calendar.startOfDay(for: date)
+        return String(start.timeIntervalSince1970)
+    }
+}
+
+struct DaySeparatorView: View {
+    let date: Date
+    var calendar: Calendar = .current
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Divider()
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Divider()
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isHeader)
+    }
+
+    private var label: String {
+        if calendar.isDateInToday(date) {
+            return "Today"
+        }
+        if calendar.isDateInYesterday(date) {
+            return "Yesterday"
+        }
+        return Self.dateFormatter.string(from: date)
+    }
+
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return formatter
+    }()
+}

--- a/AXTerm/DeterministicJSON.swift
+++ b/AXTerm/DeterministicJSON.swift
@@ -1,0 +1,31 @@
+//
+//  DeterministicJSON.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 2/2/26.
+//
+
+import Foundation
+
+enum DeterministicJSON {
+    static func encode<T: Encodable>(_ value: T) -> String? {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        guard let data = try? encoder.encode(value) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    static func encodeDictionary(_ value: [String: String]) -> String? {
+        guard JSONSerialization.isValidJSONObject(value) else { return nil }
+        guard let data = try? JSONSerialization.data(withJSONObject: value, options: [.sortedKeys]) else {
+            return nil
+        }
+        return String(data: data, encoding: .utf8)
+    }
+
+    static func decodeDictionary(_ value: String) -> [String: String]? {
+        guard let data = value.data(using: .utf8) else { return nil }
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: String] else { return nil }
+        return object
+    }
+}

--- a/AXTerm/DiagnosticsExport.swift
+++ b/AXTerm/DiagnosticsExport.swift
@@ -1,0 +1,89 @@
+//
+//  DiagnosticsExport.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 2/2/26.
+//
+
+import Foundation
+
+struct DiagnosticsReport: Encodable {
+    struct AppInfo: Encodable {
+        let name: String
+        let version: String
+        let build: String
+        let macOSVersion: String
+    }
+
+    struct SettingsSnapshot: Encodable {
+        let host: String
+        let port: String
+        let persistHistory: Bool
+        let packetRetention: Int
+        let consoleRetention: Int
+        let rawRetention: Int
+        let eventRetention: Int
+    }
+
+    struct EventSnapshot: Encodable {
+        let id: UUID
+        let createdAt: Date
+        let level: String
+        let category: String
+        let message: String
+        let metadata: [String: String]?
+    }
+
+    let app: AppInfo
+    let settings: SettingsSnapshot
+    let events: [EventSnapshot]
+}
+
+enum DiagnosticsExporter {
+    static func makeReport(settings: AppSettingsStore, events: [AppEventRecord]) -> DiagnosticsReport {
+        let bundle = Bundle.main
+        let name = bundle.object(forInfoDictionaryKey: "CFBundleName") as? String
+            ?? bundle.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
+            ?? "AXTerm"
+        let version = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "Unknown"
+        let build = bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "Unknown"
+
+        let app = DiagnosticsReport.AppInfo(
+            name: name,
+            version: version,
+            build: build,
+            macOSVersion: ProcessInfo.processInfo.operatingSystemVersionString
+        )
+
+        let snapshot = DiagnosticsReport.SettingsSnapshot(
+            host: settings.host,
+            port: settings.port,
+            persistHistory: settings.persistHistory,
+            packetRetention: settings.retentionLimit,
+            consoleRetention: settings.consoleRetentionLimit,
+            rawRetention: settings.rawRetentionLimit,
+            eventRetention: settings.eventRetentionLimit
+        )
+
+        let eventSnapshots = events.map { record in
+            DiagnosticsReport.EventSnapshot(
+                id: record.id,
+                createdAt: record.createdAt,
+                level: record.level.rawValue,
+                category: record.category.rawValue,
+                message: record.message,
+                metadata: record.metadataJSON.flatMap(DeterministicJSON.decodeDictionary)
+            )
+        }
+
+        return DiagnosticsReport(app: app, settings: snapshot, events: eventSnapshots)
+    }
+
+    static func makeJSON(report: DiagnosticsReport) -> String? {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        guard let data = try? encoder.encode(report) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+}

--- a/AXTerm/DiagnosticsView.swift
+++ b/AXTerm/DiagnosticsView.swift
@@ -1,0 +1,156 @@
+//
+//  DiagnosticsView.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 2/2/26.
+//
+
+import SwiftUI
+import AppKit
+
+@MainActor
+final class DiagnosticsViewModel: ObservableObject {
+    @Published var events: [AppEventRecord] = []
+    @Published var copyFeedback: String?
+
+    private let settings: AppSettingsStore
+    private let eventStore: EventLogStore?
+    private let displayLimit = 2_000
+    private let exportLimit = 1_000
+
+    init(settings: AppSettingsStore, eventStore: EventLogStore?) {
+        self.settings = settings
+        self.eventStore = eventStore
+    }
+
+    func load() {
+        guard let eventStore else {
+            events = []
+            return
+        }
+        let limit = min(settings.eventRetentionLimit, displayLimit)
+        DispatchQueue.global(qos: .utility).async { [eventStore] in
+            let records = (try? eventStore.loadRecent(limit: limit)) ?? []
+            Task { @MainActor in
+                self.events = records.reversed()
+            }
+        }
+    }
+
+    func copyDiagnostics() {
+        makeReportJSON(limit: exportLimit) { [weak self] json in
+            guard let json else { return }
+            ClipboardWriter.copy(json)
+            self?.showCopyFeedback()
+        }
+    }
+
+    func exportDiagnostics() {
+        makeReportJSON(limit: exportLimit) { [weak self] json in
+            guard let json else { return }
+            let panel = NSSavePanel()
+            panel.allowedFileTypes = ["json"]
+            panel.nameFieldStringValue = "AXTerm-Diagnostics.json"
+            panel.canCreateDirectories = true
+            panel.begin { response in
+                guard response == .OK, let url = panel.url else { return }
+                do {
+                    try json.write(to: url, atomically: true, encoding: .utf8)
+                } catch {
+                    return
+                }
+            }
+        }
+    }
+
+    private func makeReportJSON(limit: Int, completion: @escaping (String?) -> Void) {
+        let report = DiagnosticsExporter.makeReport(settings: settings, events: Array(events.suffix(limit)))
+        completion(DiagnosticsExporter.makeJSON(report: report))
+    }
+
+    private func showCopyFeedback() {
+        copyFeedback = "Copied"
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            copyFeedback = nil
+        }
+    }
+}
+
+struct DiagnosticsView: View {
+    @StateObject private var model: DiagnosticsViewModel
+
+    init(settings: AppSettingsStore, eventStore: EventLogStore?) {
+        _model = StateObject(wrappedValue: DiagnosticsViewModel(settings: settings, eventStore: eventStore))
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            Table(model.events) {
+                TableColumn("Time") { event in
+                    Text(Self.timeFormatter.string(from: event.createdAt))
+                        .foregroundStyle(.secondary)
+                }
+                TableColumn("Level") { event in
+                    Text(event.level.rawValue.uppercased())
+                }
+                TableColumn("Category") { event in
+                    Text(event.category.rawValue)
+                        .foregroundStyle(.secondary)
+                }
+                TableColumn("Message") { event in
+                    Text(event.message)
+                        .lineLimit(2)
+                }
+            }
+        }
+        .frame(minWidth: 700, minHeight: 400)
+        .task {
+            model.load()
+        }
+    }
+
+    private var header: some View {
+        HStack {
+            Text("Diagnostics")
+                .font(.headline)
+
+            Spacer()
+
+            Text("\(model.events.count) events")
+                .foregroundStyle(.secondary)
+                .font(.caption)
+
+            if let feedback = model.copyFeedback {
+                Text(feedback)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Button("Copy Diagnostics") {
+                model.copyDiagnostics()
+            }
+            .buttonStyle(.bordered)
+
+            Button("Export…") {
+                model.exportDiagnostics()
+            }
+            .buttonStyle(.bordered)
+        }
+        .padding()
+        .background(.bar)
+    }
+
+    private static let timeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .none
+        formatter.timeStyle = .medium
+        return formatter
+    }()
+}
+
+#Preview {
+    DiagnosticsView(settings: AppSettingsStore(), eventStore: nil)
+}

--- a/AXTerm/EventLogger.swift
+++ b/AXTerm/EventLogger.swift
@@ -1,0 +1,64 @@
+//
+//  EventLogger.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 2/2/26.
+//
+
+import Foundation
+import OSLog
+
+protocol EventLogger {
+    func log(level: AppEventRecord.Level, category: AppEventRecord.Category, message: String, metadata: [String: String]?)
+}
+
+final class DatabaseEventLogger: EventLogger {
+    private let store: EventLogStore
+    private let settings: AppSettingsStore
+    private let logger = Logger(subsystem: "AXTerm", category: "Diagnostics")
+
+    init(store: EventLogStore, settings: AppSettingsStore) {
+        self.store = store
+        self.settings = settings
+    }
+
+    func log(level: AppEventRecord.Level, category: AppEventRecord.Category, message: String, metadata: [String: String]?) {
+        let metadataJSON = metadata.flatMap(DeterministicJSON.encodeDictionary)
+        let entry = AppEventRecord(
+            id: UUID(),
+            createdAt: Date(),
+            level: level,
+            category: category,
+            message: message,
+            metadataJSON: metadataJSON
+        )
+
+        logToOSLog(entry)
+
+        DispatchQueue.global(qos: .utility).async { [store, settings] in
+            do {
+                try store.append(entry)
+                try store.pruneIfNeeded(retentionLimit: settings.eventRetentionLimit)
+            } catch {
+                return
+            }
+        }
+    }
+
+    private func logToOSLog(_ entry: AppEventRecord) {
+        switch entry.level {
+        case .info:
+            logger.info("\(entry.category.rawValue): \(entry.message, privacy: .public)")
+        case .warning:
+            logger.warning("\(entry.category.rawValue): \(entry.message, privacy: .public)")
+        case .error:
+            logger.error("\(entry.category.rawValue): \(entry.message, privacy: .public)")
+        }
+    }
+}
+
+final class NoopEventLogger: EventLogger {
+    func log(level: AppEventRecord.Level, category: AppEventRecord.Category, message: String, metadata: [String: String]?) {
+        return
+    }
+}

--- a/AXTerm/Persistence/AppEventRecord.swift
+++ b/AXTerm/Persistence/AppEventRecord.swift
@@ -1,0 +1,35 @@
+//
+//  AppEventRecord.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 2/2/26.
+//
+
+import Foundation
+import GRDB
+
+struct AppEventRecord: Codable, FetchableRecord, PersistableRecord, Hashable, Identifiable {
+    static let databaseTableName = "app_events"
+
+    enum Level: String, Codable {
+        case info
+        case warning
+        case error
+    }
+
+    enum Category: String, Codable {
+        case connection
+        case parser
+        case store
+        case ui
+        case settings
+        case packet
+    }
+
+    var id: UUID
+    var createdAt: Date
+    var level: Level
+    var category: Category
+    var message: String
+    var metadataJSON: String?
+}

--- a/AXTerm/Persistence/ConsoleEntryRecord.swift
+++ b/AXTerm/Persistence/ConsoleEntryRecord.swift
@@ -1,0 +1,67 @@
+//
+//  ConsoleEntryRecord.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 2/2/26.
+//
+
+import Foundation
+import GRDB
+
+struct ConsoleEntryRecord: Codable, FetchableRecord, PersistableRecord, Hashable {
+    static let databaseTableName = "console_entries"
+
+    enum Level: String, Codable {
+        case info
+        case warning
+        case error
+        case system
+    }
+
+    enum Category: String, Codable {
+        case connection
+        case parser
+        case store
+        case ui
+        case packet
+        case system
+    }
+
+    var id: UUID
+    var createdAt: Date
+    var level: Level
+    var category: Category
+    var message: String
+    var packetID: UUID?
+    var metadataJSON: String?
+    var byteCount: Int?
+
+    func toConsoleLine() -> ConsoleLine {
+        let metadata = metadataJSON.flatMap(DeterministicJSON.decodeDictionary)
+        let from = metadata?["from"]
+        let to = metadata?["to"]
+        return ConsoleLine(
+            id: id,
+            kind: ConsoleLine.Kind(from: level),
+            timestamp: createdAt,
+            from: from,
+            to: to,
+            text: message
+        )
+    }
+}
+
+private extension ConsoleLine.Kind {
+    init(from level: ConsoleEntryRecord.Level) {
+        switch level {
+        case .system:
+            self = .system
+        case .error:
+            self = .error
+        case .warning:
+            self = .system
+        case .info:
+            self = .packet
+        }
+    }
+}

--- a/AXTerm/Persistence/ConsoleStore.swift
+++ b/AXTerm/Persistence/ConsoleStore.swift
@@ -1,0 +1,15 @@
+//
+//  ConsoleStore.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 2/2/26.
+//
+
+import Foundation
+
+protocol ConsoleStore {
+    func append(_ entry: ConsoleEntryRecord) throws
+    func loadRecent(limit: Int) throws -> [ConsoleEntryRecord]
+    func deleteAll() throws
+    func pruneIfNeeded(retentionLimit: Int) throws
+}

--- a/AXTerm/Persistence/DatabaseManager.swift
+++ b/AXTerm/Persistence/DatabaseManager.swift
@@ -116,6 +116,45 @@ enum DatabaseManager {
                 GROUP BY fromCall, fromSSID
                 """)
         }
+        migrator.registerMigration("createConsoleRawEvents") { db in
+            try db.create(table: ConsoleEntryRecord.databaseTableName) { table in
+                table.column("id", .text).primaryKey()
+                table.column("createdAt", .datetime).notNull()
+                table.column("level", .text).notNull()
+                table.column("category", .text).notNull()
+                table.column("message", .text).notNull()
+                table.column("packetID", .text)
+                table.column("metadataJSON", .text)
+                table.column("byteCount", .integer)
+            }
+            try db.create(index: "idx_console_createdAt", on: ConsoleEntryRecord.databaseTableName, columns: ["createdAt"])
+            try db.create(index: "idx_console_level_category", on: ConsoleEntryRecord.databaseTableName, columns: ["level", "category"])
+
+            try db.create(table: RawEntryRecord.databaseTableName) { table in
+                table.column("id", .text).primaryKey()
+                table.column("createdAt", .datetime).notNull()
+                table.column("source", .text).notNull()
+                table.column("direction", .text).notNull()
+                table.column("kind", .text).notNull()
+                table.column("rawHex", .text).notNull()
+                table.column("byteCount", .integer).notNull()
+                table.column("packetID", .text)
+                table.column("metadataJSON", .text)
+            }
+            try db.create(index: "idx_raw_createdAt", on: RawEntryRecord.databaseTableName, columns: ["createdAt"])
+            try db.create(index: "idx_raw_kind_source", on: RawEntryRecord.databaseTableName, columns: ["kind", "source"])
+
+            try db.create(table: AppEventRecord.databaseTableName) { table in
+                table.column("id", .text).primaryKey()
+                table.column("createdAt", .datetime).notNull()
+                table.column("level", .text).notNull()
+                table.column("category", .text).notNull()
+                table.column("message", .text).notNull()
+                table.column("metadataJSON", .text)
+            }
+            try db.create(index: "idx_events_createdAt", on: AppEventRecord.databaseTableName, columns: ["createdAt"])
+            try db.create(index: "idx_events_level_category", on: AppEventRecord.databaseTableName, columns: ["level", "category"])
+        }
         return migrator
     }()
 

--- a/AXTerm/Persistence/EventLogStore.swift
+++ b/AXTerm/Persistence/EventLogStore.swift
@@ -1,0 +1,15 @@
+//
+//  EventLogStore.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 2/2/26.
+//
+
+import Foundation
+
+protocol EventLogStore {
+    func append(_ entry: AppEventRecord) throws
+    func loadRecent(limit: Int) throws -> [AppEventRecord]
+    func deleteAll() throws
+    func pruneIfNeeded(retentionLimit: Int) throws
+}

--- a/AXTerm/Persistence/RawEntryRecord.swift
+++ b/AXTerm/Persistence/RawEntryRecord.swift
@@ -1,0 +1,34 @@
+//
+//  RawEntryRecord.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 2/2/26.
+//
+
+import Foundation
+import GRDB
+
+struct RawEntryRecord: Codable, FetchableRecord, PersistableRecord, Hashable {
+    static let databaseTableName = "raw_entries"
+
+    enum Kind: String, Codable {
+        case frame
+        case bytes
+        case error
+    }
+
+    var id: UUID
+    var createdAt: Date
+    var source: String
+    var direction: String
+    var kind: Kind
+    var rawHex: String
+    var byteCount: Int
+    var packetID: UUID?
+    var metadataJSON: String?
+
+    func toRawChunk() -> RawChunk {
+        let data = PacketEncoding.decodeHex(rawHex)
+        return RawChunk(id: id, timestamp: createdAt, data: data)
+    }
+}

--- a/AXTerm/Persistence/RawStore.swift
+++ b/AXTerm/Persistence/RawStore.swift
@@ -1,0 +1,15 @@
+//
+//  RawStore.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 2/2/26.
+//
+
+import Foundation
+
+protocol RawStore {
+    func append(_ entry: RawEntryRecord) throws
+    func loadRecent(limit: Int) throws -> [RawEntryRecord]
+    func deleteAll() throws
+    func pruneIfNeeded(retentionLimit: Int) throws
+}

--- a/AXTerm/Persistence/SQLiteConsoleStore.swift
+++ b/AXTerm/Persistence/SQLiteConsoleStore.swift
@@ -1,0 +1,63 @@
+//
+//  SQLiteConsoleStore.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 2/2/26.
+//
+
+import Foundation
+import GRDB
+
+final class SQLiteConsoleStore: ConsoleStore {
+    private let dbQueue: DatabaseQueue
+
+    init(dbQueue: DatabaseQueue) {
+        self.dbQueue = dbQueue
+    }
+
+    convenience init() throws {
+        try self.init(dbQueue: DatabaseManager.makeDatabaseQueue())
+    }
+
+    func append(_ entry: ConsoleEntryRecord) throws {
+        try dbQueue.write { db in
+            try entry.insert(db)
+        }
+    }
+
+    func loadRecent(limit: Int) throws -> [ConsoleEntryRecord] {
+        try dbQueue.read { db in
+            try ConsoleEntryRecord
+                .order(Column("createdAt").desc)
+                .limit(limit)
+                .fetchAll(db)
+        }
+    }
+
+    func deleteAll() throws {
+        try dbQueue.write { db in
+            _ = try ConsoleEntryRecord.deleteAll(db)
+        }
+    }
+
+    func pruneIfNeeded(retentionLimit: Int) throws {
+        guard retentionLimit > 0 else { return }
+        try dbQueue.write { db in
+            let total = try ConsoleEntryRecord.fetchCount(db)
+            guard total > retentionLimit else { return }
+            let overflow = total - retentionLimit
+            if overflow <= 0 { return }
+            try db.execute(
+                sql: """
+                DELETE FROM \(ConsoleEntryRecord.databaseTableName)
+                WHERE id IN (
+                    SELECT id FROM \(ConsoleEntryRecord.databaseTableName)
+                    ORDER BY createdAt ASC
+                    LIMIT ?
+                )
+                """,
+                arguments: [overflow]
+            )
+        }
+    }
+}

--- a/AXTerm/Persistence/SQLiteEventLogStore.swift
+++ b/AXTerm/Persistence/SQLiteEventLogStore.swift
@@ -1,0 +1,63 @@
+//
+//  SQLiteEventLogStore.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 2/2/26.
+//
+
+import Foundation
+import GRDB
+
+final class SQLiteEventLogStore: EventLogStore {
+    private let dbQueue: DatabaseQueue
+
+    init(dbQueue: DatabaseQueue) {
+        self.dbQueue = dbQueue
+    }
+
+    convenience init() throws {
+        try self.init(dbQueue: DatabaseManager.makeDatabaseQueue())
+    }
+
+    func append(_ entry: AppEventRecord) throws {
+        try dbQueue.write { db in
+            try entry.insert(db)
+        }
+    }
+
+    func loadRecent(limit: Int) throws -> [AppEventRecord] {
+        try dbQueue.read { db in
+            try AppEventRecord
+                .order(Column("createdAt").desc)
+                .limit(limit)
+                .fetchAll(db)
+        }
+    }
+
+    func deleteAll() throws {
+        try dbQueue.write { db in
+            _ = try AppEventRecord.deleteAll(db)
+        }
+    }
+
+    func pruneIfNeeded(retentionLimit: Int) throws {
+        guard retentionLimit > 0 else { return }
+        try dbQueue.write { db in
+            let total = try AppEventRecord.fetchCount(db)
+            guard total > retentionLimit else { return }
+            let overflow = total - retentionLimit
+            if overflow <= 0 { return }
+            try db.execute(
+                sql: """
+                DELETE FROM \(AppEventRecord.databaseTableName)
+                WHERE id IN (
+                    SELECT id FROM \(AppEventRecord.databaseTableName)
+                    ORDER BY createdAt ASC
+                    LIMIT ?
+                )
+                """,
+                arguments: [overflow]
+            )
+        }
+    }
+}

--- a/AXTerm/Persistence/SQLiteRawStore.swift
+++ b/AXTerm/Persistence/SQLiteRawStore.swift
@@ -1,0 +1,63 @@
+//
+//  SQLiteRawStore.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 2/2/26.
+//
+
+import Foundation
+import GRDB
+
+final class SQLiteRawStore: RawStore {
+    private let dbQueue: DatabaseQueue
+
+    init(dbQueue: DatabaseQueue) {
+        self.dbQueue = dbQueue
+    }
+
+    convenience init() throws {
+        try self.init(dbQueue: DatabaseManager.makeDatabaseQueue())
+    }
+
+    func append(_ entry: RawEntryRecord) throws {
+        try dbQueue.write { db in
+            try entry.insert(db)
+        }
+    }
+
+    func loadRecent(limit: Int) throws -> [RawEntryRecord] {
+        try dbQueue.read { db in
+            try RawEntryRecord
+                .order(Column("createdAt").desc)
+                .limit(limit)
+                .fetchAll(db)
+        }
+    }
+
+    func deleteAll() throws {
+        try dbQueue.write { db in
+            _ = try RawEntryRecord.deleteAll(db)
+        }
+    }
+
+    func pruneIfNeeded(retentionLimit: Int) throws {
+        guard retentionLimit > 0 else { return }
+        try dbQueue.write { db in
+            let total = try RawEntryRecord.fetchCount(db)
+            guard total > retentionLimit else { return }
+            let overflow = total - retentionLimit
+            if overflow <= 0 { return }
+            try db.execute(
+                sql: """
+                DELETE FROM \(RawEntryRecord.databaseTableName)
+                WHERE id IN (
+                    SELECT id FROM \(RawEntryRecord.databaseTableName)
+                    ORDER BY createdAt ASC
+                    LIMIT ?
+                )
+                """,
+                arguments: [overflow]
+            )
+        }
+    }
+}

--- a/AXTerm/RawEntryEncoding.swift
+++ b/AXTerm/RawEntryEncoding.swift
@@ -1,0 +1,14 @@
+//
+//  RawEntryEncoding.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 2/2/26.
+//
+
+import Foundation
+
+enum RawEntryEncoding {
+    static func encodeHex(_ data: Data) -> String {
+        data.map { String(format: "%02X", $0) }.joined(separator: " ")
+    }
+}

--- a/AXTerm/RawView.swift
+++ b/AXTerm/RawView.swift
@@ -10,6 +10,7 @@ import AppKit
 
 struct RawView: View {
     let chunks: [RawChunk]
+    let showDaySeparators: Bool
     let onClear: () -> Void
 
     @State private var autoScroll = true
@@ -41,9 +42,21 @@ struct RawView: View {
             ScrollViewReader { proxy in
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 4) {
-                        ForEach(chunks) { chunk in
-                            RawChunkView(chunk: chunk)
-                                .id(chunk.id)
+                        if showDaySeparators {
+                            ForEach(groupedChunks) { section in
+                                DaySeparatorView(date: section.date)
+                                    .padding(.vertical, 4)
+
+                                ForEach(section.items) { chunk in
+                                    RawChunkView(chunk: chunk)
+                                        .id(chunk.id)
+                                }
+                            }
+                        } else {
+                            ForEach(chunks) { chunk in
+                                RawChunkView(chunk: chunk)
+                                    .id(chunk.id)
+                            }
                         }
                     }
                     .padding()
@@ -59,6 +72,10 @@ struct RawView: View {
             }
             .background(.background)
         }
+    }
+
+    private var groupedChunks: [DayGroupedSection<RawChunk>] {
+        DayGrouping.group(items: chunks, date: { $0.timestamp })
     }
 }
 

--- a/AXTerm/Settings/SettingsView.swift
+++ b/AXTerm/Settings/SettingsView.swift
@@ -11,6 +11,9 @@ struct SettingsView: View {
     @ObservedObject var settings: AppSettingsStore
     @ObservedObject var client: KISSTcpClient
     let packetStore: PacketStore?
+    let consoleStore: ConsoleStore?
+    let rawStore: RawStore?
+    let eventLogger: EventLogger?
 
     @State private var showingClearConfirmation = false
     @State private var clearFeedback: String?
@@ -38,7 +41,7 @@ struct SettingsView: View {
 
                 VStack(alignment: .leading, spacing: 8) {
                     HStack {
-                        Text("Retention limit")
+                        Text("Packet retention")
                         Spacer()
                         Text("\(settings.retentionLimit) packets")
                             .foregroundStyle(.secondary)
@@ -69,6 +72,72 @@ struct SettingsView: View {
                 }
                 .disabled(!settings.persistHistory)
 
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text("Console retention")
+                        Spacer()
+                        Text("\(settings.consoleRetentionLimit) lines")
+                            .foregroundStyle(.secondary)
+                    }
+
+                    HStack(spacing: 8) {
+                        TextField(
+                            "",
+                            value: $settings.consoleRetentionLimit,
+                            format: .number
+                        )
+                        .frame(width: 80)
+                        .textFieldStyle(.roundedBorder)
+                        .accessibilityLabel("Console retention")
+
+                        Stepper(
+                            "",
+                            value: $settings.consoleRetentionLimit,
+                            in: AppSettingsStore.minLogRetention...AppSettingsStore.maxLogRetention,
+                            step: retentionStep
+                        )
+                        .labelsHidden()
+                    }
+
+                    Text("Console history includes system messages and packet summaries.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .disabled(!settings.persistHistory)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text("Raw retention")
+                        Spacer()
+                        Text("\(settings.rawRetentionLimit) chunks")
+                            .foregroundStyle(.secondary)
+                    }
+
+                    HStack(spacing: 8) {
+                        TextField(
+                            "",
+                            value: $settings.rawRetentionLimit,
+                            format: .number
+                        )
+                        .frame(width: 80)
+                        .textFieldStyle(.roundedBorder)
+                        .accessibilityLabel("Raw retention")
+
+                        Stepper(
+                            "",
+                            value: $settings.rawRetentionLimit,
+                            in: AppSettingsStore.minLogRetention...AppSettingsStore.maxLogRetention,
+                            step: retentionStep
+                        )
+                        .labelsHidden()
+                    }
+
+                    Text("Raw history stores KISS byte streams and parse errors.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .disabled(!settings.persistHistory)
+
                 HStack {
                     Button("Clear History…") {
                         showingClearConfirmation = true
@@ -80,6 +149,45 @@ struct SettingsView: View {
                             .foregroundStyle(.secondary)
                     }
                 }
+            }
+
+            Section("Diagnostics") {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text("Event retention")
+                        Spacer()
+                        Text("\(settings.eventRetentionLimit) events")
+                            .foregroundStyle(.secondary)
+                    }
+
+                    HStack(spacing: 8) {
+                        TextField(
+                            "",
+                            value: $settings.eventRetentionLimit,
+                            format: .number
+                        )
+                        .frame(width: 80)
+                        .textFieldStyle(.roundedBorder)
+                        .accessibilityLabel("Event retention")
+
+                        Stepper(
+                            "",
+                            value: $settings.eventRetentionLimit,
+                            in: AppSettingsStore.minLogRetention...AppSettingsStore.maxLogRetention,
+                            step: retentionStep
+                        )
+                        .labelsHidden()
+                    }
+
+                    Text("Diagnostics entries are retained separately from packet history.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Section("Display") {
+                Toggle("Console day separators", isOn: $settings.showConsoleDaySeparators)
+                Toggle("Raw day separators", isOn: $settings.showRawDaySeparators)
             }
         }
         .formStyle(.grouped)
@@ -93,7 +201,39 @@ struct SettingsView: View {
                 clearHistory()
             }
         } message: {
-            Text("This removes all persisted packets. Live packets will continue to appear.")
+            Text("This removes persisted packets, console history, and raw history. Live data will continue to appear.")
+        }
+        .onChange(of: settings.retentionLimit) { _, newValue in
+            eventLogger?.log(
+                level: .info,
+                category: .settings,
+                message: "Packet retention set to \(newValue)",
+                metadata: ["retention": "\(newValue)"]
+            )
+        }
+        .onChange(of: settings.consoleRetentionLimit) { _, newValue in
+            eventLogger?.log(
+                level: .info,
+                category: .settings,
+                message: "Console retention set to \(newValue)",
+                metadata: ["retention": "\(newValue)"]
+            )
+        }
+        .onChange(of: settings.rawRetentionLimit) { _, newValue in
+            eventLogger?.log(
+                level: .info,
+                category: .settings,
+                message: "Raw retention set to \(newValue)",
+                metadata: ["retention": "\(newValue)"]
+            )
+        }
+        .onChange(of: settings.eventRetentionLimit) { _, newValue in
+            eventLogger?.log(
+                level: .info,
+                category: .settings,
+                message: "Event retention set to \(newValue)",
+                metadata: ["retention": "\(newValue)"]
+            )
         }
     }
 
@@ -110,16 +250,21 @@ struct SettingsView: View {
 
     private func clearHistory() {
         clearFeedback = nil
-        DispatchQueue.global(qos: .utility).async { [packetStore] in
+        DispatchQueue.global(qos: .utility).async { [packetStore, consoleStore, rawStore] in
             do {
                 try packetStore?.deleteAll()
+                try consoleStore?.deleteAll()
+                try rawStore?.deleteAll()
             } catch {
                 return
             }
             DispatchQueue.main.async {
                 client.clearPackets()
                 client.clearStations()
+                client.clearConsole(clearPersisted: false)
+                client.clearRaw(clearPersisted: false)
                 clearFeedback = "Cleared"
+                eventLogger?.log(level: .info, category: .ui, message: "Cleared history", metadata: nil)
                 Task { @MainActor in
                     try? await Task.sleep(nanoseconds: 1_500_000_000)
                     clearFeedback = nil
@@ -133,6 +278,9 @@ struct SettingsView: View {
     SettingsView(
         settings: AppSettingsStore(),
         client: KISSTcpClient(settings: AppSettingsStore()),
-        packetStore: nil
+        packetStore: nil,
+        consoleStore: nil,
+        rawStore: nil,
+        eventLogger: nil
     )
 }

--- a/AXTermTests/AppSettingsStoreTests.swift
+++ b/AXTermTests/AppSettingsStoreTests.swift
@@ -26,4 +26,10 @@ final class AppSettingsStoreTests: XCTestCase {
         XCTAssertEqual(AppSettingsStore.sanitizeRetention(600_000), AppSettingsStore.maxRetention)
         XCTAssertEqual(AppSettingsStore.sanitizeRetention(50_000), 50_000)
     }
+
+    func testLogRetentionValidationClamps() {
+        XCTAssertEqual(AppSettingsStore.sanitizeLogRetention(10), AppSettingsStore.minLogRetention)
+        XCTAssertEqual(AppSettingsStore.sanitizeLogRetention(600_000), AppSettingsStore.maxLogRetention)
+        XCTAssertEqual(AppSettingsStore.sanitizeLogRetention(10_000), 10_000)
+    }
 }

--- a/AXTermTests/DayGroupingTests.swift
+++ b/AXTermTests/DayGroupingTests.swift
@@ -1,0 +1,48 @@
+//
+//  DayGroupingTests.swift
+//  AXTermTests
+//
+//  Created by Ross Wardrup on 2/2/26.
+//
+
+import XCTest
+@testable import AXTerm
+
+final class DayGroupingTests: XCTestCase {
+    func testGroupingAcrossMidnight() {
+        let calendar = Calendar(identifier: .gregorian)
+        let zone = TimeZone(secondsFromGMT: 0) ?? .current
+        var fixedCalendar = calendar
+        fixedCalendar.timeZone = zone
+
+        let items = [
+            TestItem(id: UUID(), date: Date(timeIntervalSince1970: 1_000)),
+            TestItem(id: UUID(), date: Date(timeIntervalSince1970: 2_000)),
+            TestItem(id: UUID(), date: Date(timeIntervalSince1970: 86_401))
+        ]
+
+        let grouped = DayGrouping.group(items: items, date: { $0.date }, calendar: fixedCalendar)
+        XCTAssertEqual(grouped.count, 2)
+        XCTAssertEqual(grouped.first?.items.count, 2)
+        XCTAssertEqual(grouped.last?.items.count, 1)
+    }
+
+    func testGroupingStableInTimezone() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: -8 * 3600) ?? .current
+
+        let base = Date(timeIntervalSince1970: 1_700_000_000)
+        let items = [
+            TestItem(id: UUID(), date: base),
+            TestItem(id: UUID(), date: base.addingTimeInterval(60 * 60))
+        ]
+
+        let grouped = DayGrouping.group(items: items, date: { $0.date }, calendar: calendar)
+        XCTAssertEqual(grouped.count, 1)
+    }
+
+    private struct TestItem: Identifiable {
+        let id: UUID
+        let date: Date
+    }
+}

--- a/AXTermTests/DiagnosticsExporterTests.swift
+++ b/AXTermTests/DiagnosticsExporterTests.swift
@@ -1,0 +1,39 @@
+//
+//  DiagnosticsExporterTests.swift
+//  AXTermTests
+//
+//  Created by Ross Wardrup on 2/2/26.
+//
+
+import XCTest
+@testable import AXTerm
+
+final class DiagnosticsExporterTests: XCTestCase {
+    func testExportIncludesRequiredKeys() throws {
+        let settings = makeSettings()
+        let event = AppEventRecord(
+            id: UUID(),
+            createdAt: Date(),
+            level: .info,
+            category: .settings,
+            message: "Retention updated",
+            metadataJSON: DeterministicJSON.encodeDictionary(["retention": "1000"])
+        )
+        let report = DiagnosticsExporter.makeReport(settings: settings, events: [event])
+        let json = DiagnosticsExporter.makeJSON(report: report)
+        XCTAssertNotNil(json)
+
+        let data = try XCTUnwrap(json?.data(using: .utf8))
+        let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        XCTAssertNotNil(object?["app"])
+        XCTAssertNotNil(object?["settings"])
+        let events = object?["events"] as? [[String: Any]]
+        XCTAssertEqual(events?.count, 1)
+    }
+
+    private func makeSettings() -> AppSettingsStore {
+        let suiteName = "AXTermTests-Diagnostics-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName) ?? .standard
+        return AppSettingsStore(defaults: defaults)
+    }
+}

--- a/AXTermTests/EventLoggerTests.swift
+++ b/AXTermTests/EventLoggerTests.swift
@@ -1,0 +1,39 @@
+//
+//  EventLoggerTests.swift
+//  AXTermTests
+//
+//  Created by Ross Wardrup on 2/2/26.
+//
+
+import XCTest
+@testable import AXTerm
+
+final class EventLoggerTests: XCTestCase {
+    func testDatabaseLoggerWritesEvent() async {
+        let store = MockEventLogStore()
+        let settings = makeSettings()
+        let logger = DatabaseEventLogger(store: store, settings: settings)
+
+        logger.log(level: .info, category: .ui, message: "Copied diagnostics", metadata: ["source": "test"])
+
+        await waitForStore(store)
+        XCTAssertEqual(store.appendedEntries.count, 1)
+        XCTAssertEqual(store.appendedEntries.first?.message, "Copied diagnostics")
+    }
+
+    private func makeSettings() -> AppSettingsStore {
+        let suiteName = "AXTermTests-EventLogger-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName) ?? .standard
+        defaults.set(true, forKey: AppSettingsStore.persistKey)
+        return AppSettingsStore(defaults: defaults)
+    }
+
+    private func waitForStore(_ store: MockEventLogStore) async {
+        for _ in 0..<10 {
+            if !store.appendedEntries.isEmpty || !store.pruneCalls.isEmpty {
+                return
+            }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+    }
+}

--- a/AXTermTests/MockLogStores.swift
+++ b/AXTermTests/MockLogStores.swift
@@ -1,0 +1,83 @@
+//
+//  MockLogStores.swift
+//  AXTermTests
+//
+//  Created by Ross Wardrup on 2/2/26.
+//
+
+import Foundation
+@testable import AXTerm
+
+final class MockConsoleStore: ConsoleStore {
+    private(set) var appendedEntries: [ConsoleEntryRecord] = []
+    private(set) var deleteAllCalled = false
+    private(set) var pruneCalls: [Int] = []
+
+    func append(_ entry: ConsoleEntryRecord) throws {
+        appendedEntries.append(entry)
+    }
+
+    func loadRecent(limit: Int) throws -> [ConsoleEntryRecord] {
+        Array(appendedEntries.suffix(limit)).reversed()
+    }
+
+    func deleteAll() throws {
+        deleteAllCalled = true
+    }
+
+    func pruneIfNeeded(retentionLimit: Int) throws {
+        pruneCalls.append(retentionLimit)
+    }
+}
+
+final class MockRawStore: RawStore {
+    private(set) var appendedEntries: [RawEntryRecord] = []
+    private(set) var deleteAllCalled = false
+    private(set) var pruneCalls: [Int] = []
+
+    func append(_ entry: RawEntryRecord) throws {
+        appendedEntries.append(entry)
+    }
+
+    func loadRecent(limit: Int) throws -> [RawEntryRecord] {
+        Array(appendedEntries.suffix(limit)).reversed()
+    }
+
+    func deleteAll() throws {
+        deleteAllCalled = true
+    }
+
+    func pruneIfNeeded(retentionLimit: Int) throws {
+        pruneCalls.append(retentionLimit)
+    }
+}
+
+final class MockEventLogStore: EventLogStore {
+    private(set) var appendedEntries: [AppEventRecord] = []
+    private(set) var deleteAllCalled = false
+    private(set) var pruneCalls: [Int] = []
+
+    func append(_ entry: AppEventRecord) throws {
+        appendedEntries.append(entry)
+    }
+
+    func loadRecent(limit: Int) throws -> [AppEventRecord] {
+        Array(appendedEntries.suffix(limit)).reversed()
+    }
+
+    func deleteAll() throws {
+        deleteAllCalled = true
+    }
+
+    func pruneIfNeeded(retentionLimit: Int) throws {
+        pruneCalls.append(retentionLimit)
+    }
+}
+
+final class MockEventLogger: EventLogger {
+    private(set) var entries: [(AppEventRecord.Level, AppEventRecord.Category, String, [String: String]?)] = []
+
+    func log(level: AppEventRecord.Level, category: AppEventRecord.Category, message: String, metadata: [String: String]?) {
+        entries.append((level, category, message, metadata))
+    }
+}

--- a/AXTermTests/PacketHandlingTests.swift
+++ b/AXTermTests/PacketHandlingTests.swift
@@ -13,7 +13,19 @@ final class PacketHandlingTests: XCTestCase {
     func testHandleIncomingPacketPersistsWhenEnabled() async {
         let settings = makeSettings(persistHistory: true)
         let store = MockPacketStore()
-        let client = KISSTcpClient(maxPackets: 10, maxConsoleLines: 10, maxRawChunks: 10, settings: settings, packetStore: store)
+        let consoleStore = MockConsoleStore()
+        let rawStore = MockRawStore()
+        let eventLogger = MockEventLogger()
+        let client = KISSTcpClient(
+            maxPackets: 10,
+            maxConsoleLines: 10,
+            maxRawChunks: 10,
+            settings: settings,
+            packetStore: store,
+            consoleStore: consoleStore,
+            rawStore: rawStore,
+            eventLogger: eventLogger
+        )
 
         let packet = Packet(
             timestamp: Date(),
@@ -26,18 +38,34 @@ final class PacketHandlingTests: XCTestCase {
         )
 
         client.handleIncomingPacket(packet)
+        client.handleIncomingData(Data([0x01, 0x02, 0x03]))
 
         XCTAssertEqual(client.packets.count, 1)
         XCTAssertEqual(client.stations.count, 1)
 
         await waitForStore(store)
+        await waitForConsoleStore(consoleStore)
+        await waitForRawStore(rawStore)
         XCTAssertEqual(store.savedPackets.count, 1)
+        XCTAssertEqual(consoleStore.appendedEntries.count, 1)
+        XCTAssertEqual(rawStore.appendedEntries.count, 1)
     }
 
     func testHandleIncomingPacketSkipsPersistenceWhenDisabled() async {
         let settings = makeSettings(persistHistory: false)
         let store = MockPacketStore()
-        let client = KISSTcpClient(maxPackets: 10, maxConsoleLines: 10, maxRawChunks: 10, settings: settings, packetStore: store)
+        let consoleStore = MockConsoleStore()
+        let rawStore = MockRawStore()
+        let client = KISSTcpClient(
+            maxPackets: 10,
+            maxConsoleLines: 10,
+            maxRawChunks: 10,
+            settings: settings,
+            packetStore: store,
+            consoleStore: consoleStore,
+            rawStore: rawStore,
+            eventLogger: nil
+        )
 
         let packet = Packet(
             timestamp: Date(),
@@ -50,10 +78,32 @@ final class PacketHandlingTests: XCTestCase {
         )
 
         client.handleIncomingPacket(packet)
+        client.handleIncomingData(Data([0x01, 0x02, 0x03]))
 
         XCTAssertEqual(client.packets.count, 1)
         await waitForStore(store)
         XCTAssertEqual(store.savedPackets.count, 0)
+        XCTAssertEqual(consoleStore.appendedEntries.count, 0)
+        XCTAssertEqual(rawStore.appendedEntries.count, 0)
+    }
+
+    func testConnectInvalidPortLogsEvent() {
+        let settings = makeSettings(persistHistory: true)
+        let eventLogger = MockEventLogger()
+        let client = KISSTcpClient(
+            maxPackets: 1,
+            maxConsoleLines: 1,
+            maxRawChunks: 1,
+            settings: settings,
+            packetStore: nil,
+            consoleStore: nil,
+            rawStore: nil,
+            eventLogger: eventLogger
+        )
+
+        client.connect(host: "localhost", port: 0)
+
+        XCTAssertTrue(eventLogger.entries.contains(where: { $0.0 == .error && $0.1 == .connection }))
     }
 
     private func makeSettings(persistHistory: Bool) -> AppSettingsStore {
@@ -66,6 +116,24 @@ final class PacketHandlingTests: XCTestCase {
     private func waitForStore(_ store: MockPacketStore) async {
         for _ in 0..<10 {
             if !store.savedPackets.isEmpty || !store.pruneCalls.isEmpty {
+                return
+            }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+    }
+
+    private func waitForConsoleStore(_ store: MockConsoleStore) async {
+        for _ in 0..<10 {
+            if !store.appendedEntries.isEmpty || !store.pruneCalls.isEmpty {
+                return
+            }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+    }
+
+    private func waitForRawStore(_ store: MockRawStore) async {
+        for _ in 0..<10 {
+            if !store.appendedEntries.isEmpty || !store.pruneCalls.isEmpty {
                 return
             }
             try? await Task.sleep(nanoseconds: 50_000_000)

--- a/AXTermTests/SQLiteConsoleStoreTests.swift
+++ b/AXTermTests/SQLiteConsoleStoreTests.swift
@@ -1,0 +1,52 @@
+//
+//  SQLiteConsoleStoreTests.swift
+//  AXTermTests
+//
+//  Created by Ross Wardrup on 2/2/26.
+//
+
+import XCTest
+import GRDB
+@testable import AXTerm
+
+final class SQLiteConsoleStoreTests: XCTestCase {
+    func testRoundTripOrderingAndPrune() throws {
+        let store = try makeStore()
+        let first = ConsoleEntryRecord(
+            id: UUID(),
+            createdAt: Date(timeIntervalSince1970: 10),
+            level: .info,
+            category: .packet,
+            message: "First",
+            packetID: nil,
+            metadataJSON: nil,
+            byteCount: nil
+        )
+        let second = ConsoleEntryRecord(
+            id: UUID(),
+            createdAt: Date(timeIntervalSince1970: 20),
+            level: .system,
+            category: .connection,
+            message: "Second",
+            packetID: nil,
+            metadataJSON: nil,
+            byteCount: nil
+        )
+        try store.append(first)
+        try store.append(second)
+
+        let recent = try store.loadRecent(limit: 10)
+        XCTAssertEqual(recent.map(\.id), [second.id, first.id])
+
+        try store.pruneIfNeeded(retentionLimit: 1)
+        let remaining = try store.loadRecent(limit: 10)
+        XCTAssertEqual(remaining.count, 1)
+        XCTAssertEqual(remaining.first?.id, second.id)
+    }
+
+    private func makeStore() throws -> SQLiteConsoleStore {
+        let queue = try DatabaseQueue(path: ":memory:")
+        try DatabaseManager.migrator.migrate(queue)
+        return SQLiteConsoleStore(dbQueue: queue)
+    }
+}

--- a/AXTermTests/SQLiteEventLogStoreTests.swift
+++ b/AXTermTests/SQLiteEventLogStoreTests.swift
@@ -1,0 +1,48 @@
+//
+//  SQLiteEventLogStoreTests.swift
+//  AXTermTests
+//
+//  Created by Ross Wardrup on 2/2/26.
+//
+
+import XCTest
+import GRDB
+@testable import AXTerm
+
+final class SQLiteEventLogStoreTests: XCTestCase {
+    func testRoundTripOrderingAndPrune() throws {
+        let store = try makeStore()
+        let first = AppEventRecord(
+            id: UUID(),
+            createdAt: Date(timeIntervalSince1970: 3),
+            level: .info,
+            category: .settings,
+            message: "First",
+            metadataJSON: nil
+        )
+        let second = AppEventRecord(
+            id: UUID(),
+            createdAt: Date(timeIntervalSince1970: 7),
+            level: .error,
+            category: .connection,
+            message: "Second",
+            metadataJSON: nil
+        )
+        try store.append(first)
+        try store.append(second)
+
+        let recent = try store.loadRecent(limit: 10)
+        XCTAssertEqual(recent.map(\.id), [second.id, first.id])
+
+        try store.pruneIfNeeded(retentionLimit: 1)
+        let remaining = try store.loadRecent(limit: 10)
+        XCTAssertEqual(remaining.count, 1)
+        XCTAssertEqual(remaining.first?.id, second.id)
+    }
+
+    private func makeStore() throws -> SQLiteEventLogStore {
+        let queue = try DatabaseQueue(path: ":memory:")
+        try DatabaseManager.migrator.migrate(queue)
+        return SQLiteEventLogStore(dbQueue: queue)
+    }
+}

--- a/AXTermTests/SQLiteRawStoreTests.swift
+++ b/AXTermTests/SQLiteRawStoreTests.swift
@@ -1,0 +1,57 @@
+//
+//  SQLiteRawStoreTests.swift
+//  AXTermTests
+//
+//  Created by Ross Wardrup on 2/2/26.
+//
+
+import XCTest
+import GRDB
+@testable import AXTerm
+
+final class SQLiteRawStoreTests: XCTestCase {
+    func testRoundTripOrderingAndPrune() throws {
+        let store = try makeStore()
+        let data = Data([0x01, 0x02])
+        let first = RawEntryRecord(
+            id: UUID(),
+            createdAt: Date(timeIntervalSince1970: 5),
+            source: "kiss",
+            direction: "rx",
+            kind: .bytes,
+            rawHex: RawEntryEncoding.encodeHex(data),
+            byteCount: data.count,
+            packetID: nil,
+            metadataJSON: nil
+        )
+        let second = RawEntryRecord(
+            id: UUID(),
+            createdAt: Date(timeIntervalSince1970: 15),
+            source: "kiss",
+            direction: "rx",
+            kind: .bytes,
+            rawHex: RawEntryEncoding.encodeHex(Data([0x03])),
+            byteCount: 1,
+            packetID: nil,
+            metadataJSON: nil
+        )
+        try store.append(first)
+        try store.append(second)
+
+        let recent = try store.loadRecent(limit: 10)
+        XCTAssertEqual(recent.map(\.id), [second.id, first.id])
+        XCTAssertEqual(recent.last?.rawHex, RawEntryEncoding.encodeHex(data))
+        XCTAssertEqual(recent.last?.toRawChunk().data, data)
+
+        try store.pruneIfNeeded(retentionLimit: 1)
+        let remaining = try store.loadRecent(limit: 10)
+        XCTAssertEqual(remaining.count, 1)
+        XCTAssertEqual(remaining.first?.id, second.id)
+    }
+
+    private func makeStore() throws -> SQLiteRawStore {
+        let queue = try DatabaseQueue(path: ":memory:")
+        try DatabaseManager.migrator.migrate(queue)
+        return SQLiteRawStore(dbQueue: queue)
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide persistence for Console and Raw views so recent history is restored on launch without duplicating packet storage.
- Add a small, purpose-built diagnostics/event log persisted to SQLite for connection/errors/settings events and an exportable diagnostics snapshot.
- Offer optional, HIG-friendly day/interval separators in Console and Raw views to improve readability without harming performance.

### Description

- Database/schema: Added a `createConsoleRawEvents` migration to `DatabaseManager` and new records `ConsoleEntryRecord`, `RawEntryRecord`, and `AppEventRecord` to support `console_entries`, `raw_entries`, and `app_events` tables with indexes and the requested columns. (`AXTerm/Persistence/DatabaseManager.swift`, `AXTerm/Persistence/*.swift`).
- Stores & API: Introduced protocols `ConsoleStore`, `RawStore`, and `EventLogStore` and GRDB-backed implementations `SQLiteConsoleStore`, `SQLiteRawStore`, and `SQLiteEventLogStore`. Added deterministic JSON helpers `DeterministicJSON` and `RawEntryEncoding` for stable metadata and hex formatting. (`AXTerm/Persistence/*`).
- Integration & DI: Wire stores and an `EventLogger` into the app via `AXTermApp` and `KISSTcpClient` constructor injection; `KISSTcpClient` now persists console lines and raw chunks (append-only) and logs diagnostics events for connect/disconnect/errors/parsing; existing `PacketStore` usage is preserved. (`AXTerm/AXTermApp.swift`, `AXTerm/KISSTcpClient.swift`, `AXTerm/EventLogger.swift`).
- Settings & UI: Added retention settings for console/raw/events and toggles for day separators in `AppSettingsStore`, updated `SettingsView` UI to configure and clear history, and hooked subtle feedback into diagnostics copy/export actions. (`AXTerm/Settings/*`).
- Views & UX: `ConsoleView` and `RawView` now accept `showDaySeparators` and render tasteful, accessible day separators via a reusable `DayGrouping` helper and `DaySeparatorView`; `ContentView` threads the settings through. (`AXTerm/ConsoleView.swift`, `AXTerm/RawView.swift`, `AXTerm/DayGrouping.swift`).
- Diagnostics: Added `DiagnosticsView` window (openable from Help → Diagnostics…), a deterministic `DiagnosticsExporter` that produces JSON with app info/settings/last N events, and a `DatabaseEventLogger` that writes to DB and `OSLog`. (`AXTerm/DiagnosticsView.swift`, `AXTerm/DiagnosticsExport.swift`).
- Tests: Added unit tests for stores, event logger, diagnostics exporter, and the day-grouping helper, and extended packet handling tests to exercise the new persistence plumbing. New/changed test files include `SQLiteConsoleStoreTests`, `SQLiteRawStoreTests`, `SQLiteEventLogStoreTests`, `EventLoggerTests`, `DiagnosticsExporterTests`, `DayGroupingTests`, updates to `PacketHandlingTests`, and small settings tests. (`AXTermTests/*`).

### Testing

- Added XCTest unit tests covering: console/raw/event store round-trip ordering and pruning (`SQLiteConsoleStoreTests`, `SQLiteRawStoreTests`, `SQLiteEventLogStoreTests`), `DayGrouping` grouping behavior (`DayGroupingTests`), diagnostics export fields (`DiagnosticsExporterTests`), and the `DatabaseEventLogger` write path (`EventLoggerTests`).
- Updated `PacketHandlingTests` to validate that incoming packets trigger packet save, console append, and raw append when `persistHistory` is enabled and to ensure persistence is skipped when disabled. (`AXTermTests/PacketHandlingTests.swift`).
- Automated test execution was not possible in this environment because `xcodebuild` is not available here, so the new tests were added but not executed: attempted command `xcodebuild test -scheme AXTerm -destination 'platform=macOS'` failed with `xcodebuild` not found.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a9b3f2a708330abc517843761ed94)