### PR TITLE
Add Combine import for DiagnosticsViewModel

### DIFF
--- a/AXTerm/DiagnosticsView.swift
+++ b/AXTerm/DiagnosticsView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import AppKit
+import Combine
 
 @MainActor
 final class DiagnosticsViewModel: ObservableObject {


### PR DESCRIPTION
### Motivation
- The `DiagnosticsViewModel` uses `ObservableObject` and `@Published` but the source file lacked `import Combine`, which causes compilation failures.

### Description
- Add `import Combine` to `AXTerm/DiagnosticsView.swift` so `DiagnosticsViewModel` can use `ObservableObject` and `@Published` correctly.

### Testing
- No automated tests were run for this change; this is a one-line import fix and no build/test commands were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697aa0c15bfc8330a8d3c9336cd67592)