### PR TITLE
Add menu bar mode, watch notifications, and callsign/watch settings

### DIFF
--- a/AXTerm/AXTermApp.swift
+++ b/AXTerm/AXTermApp.swift
@@ -9,40 +9,58 @@ import SwiftUI
 
 @main
 struct AXTermApp: App {
+    @NSApplicationDelegateAdaptor(AXTermAppDelegate.self) private var appDelegate
     @StateObject private var settings: AppSettingsStore
+    @StateObject private var inspectionRouter: PacketInspectionRouter
     private let packetStore: PacketStore?
     private let consoleStore: ConsoleStore?
     private let rawStore: RawStore?
     private let eventStore: EventLogStore?
     private let eventLogger: EventLogger?
-    private let client: KISSTcpClient
+    private let notificationManager: NotificationAuthorizationManager
+    private let client: PacketEngine
 
     init() {
         let settingsStore = AppSettingsStore()
         _settings = StateObject(wrappedValue: settingsStore)
+        let router = PacketInspectionRouter()
+        _inspectionRouter = StateObject(wrappedValue: router)
         let queue = try? DatabaseManager.makeDatabaseQueue()
         let packetStore = queue.map { SQLitePacketStore(dbQueue: $0) }
         let consoleStore = queue.map { SQLiteConsoleStore(dbQueue: $0) }
         let rawStore = queue.map { SQLiteRawStore(dbQueue: $0) }
         let eventStore = queue.map { SQLiteEventLogStore(dbQueue: $0) }
         let eventLogger = eventStore.map { DatabaseEventLogger(store: $0, settings: settingsStore) }
+        let watchRecorder = eventStore.map { EventLogWatchRecorder(store: $0, settings: settingsStore) }
+        let appState = DefaultAppStateProvider()
+        let notificationScheduler = UserNotificationScheduler(settings: settingsStore, appState: appState)
+        let notificationManager = NotificationAuthorizationManager()
+        let notificationHandler = NotificationActionHandler(router: router)
         self.packetStore = packetStore
         self.consoleStore = consoleStore
         self.rawStore = rawStore
         self.eventStore = eventStore
         self.eventLogger = eventLogger
-        self.client = KISSTcpClient(
+        self.notificationManager = notificationManager
+        self.client = PacketEngine(
             settings: settingsStore,
             packetStore: packetStore,
             consoleStore: consoleStore,
             rawStore: rawStore,
-            eventLogger: eventLogger
+            eventLogger: eventLogger,
+            watchRecorder: watchRecorder,
+            notificationScheduler: notificationScheduler
         )
+        if settingsStore.autoConnectOnLaunch {
+            self.client.connect(host: settingsStore.host, port: settingsStore.portValue)
+        }
+        appDelegate.settings = settingsStore
+        appDelegate.notificationDelegate = notificationHandler
     }
 
     var body: some Scene {
-        WindowGroup {
-            ContentView(client: client, settings: settings)
+        WindowGroup("AXTerm", id: "main") {
+            ContentView(client: client, settings: settings, inspectionRouter: inspectionRouter)
         }
         .commands {
             CommandGroup(after: .windowArrangement) {
@@ -61,12 +79,21 @@ struct AXTermApp: App {
                 packetStore: packetStore,
                 consoleStore: consoleStore,
                 rawStore: rawStore,
-                eventLogger: eventLogger
+                eventLogger: eventLogger,
+                notificationManager: notificationManager
             )
         }
 
         Window("Diagnostics", id: "diagnostics") {
             DiagnosticsView(settings: settings, eventStore: eventStore)
+        }
+
+        MenuBarExtra("AXTerm", systemImage: "antenna.radiowaves.left.and.right", isInserted: $settings.runInMenuBar) {
+            MenuBarView(
+                client: client,
+                settings: settings,
+                inspectionRouter: inspectionRouter
+            )
         }
     }
 }

--- a/AXTerm/AXTermAppDelegate.swift
+++ b/AXTerm/AXTermAppDelegate.swift
@@ -1,0 +1,23 @@
+//
+//  AXTermAppDelegate.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 2/4/26.
+//
+
+import AppKit
+import UserNotifications
+
+final class AXTermAppDelegate: NSObject, NSApplicationDelegate {
+    var settings: AppSettingsStore?
+    var notificationDelegate: UNUserNotificationCenterDelegate? {
+        didSet {
+            UNUserNotificationCenter.current().delegate = notificationDelegate
+        }
+    }
+
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        guard let settings else { return false }
+        return !settings.runInMenuBar
+    }
+}

--- a/AXTerm/CallsignValidator.swift
+++ b/AXTerm/CallsignValidator.swift
@@ -1,0 +1,23 @@
+//
+//  CallsignValidator.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 2/4/26.
+//
+
+import Foundation
+
+enum CallsignValidator {
+    private static let callsignPattern = "^[A-Z0-9]{1,6}(?:-[0-9]{1,2})?$"
+
+    static func normalize(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+    }
+
+    static func isValid(_ value: String) -> Bool {
+        let normalized = normalize(value)
+        guard !normalized.isEmpty else { return false }
+        guard normalized.rangeOfCharacter(from: .letters) != nil else { return false }
+        return normalized.range(of: callsignPattern, options: [.regularExpression]) != nil
+    }
+}

--- a/AXTerm/MenuBarView.swift
+++ b/AXTerm/MenuBarView.swift
@@ -1,0 +1,127 @@
+//
+//  MenuBarView.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 2/4/26.
+//
+
+import SwiftUI
+
+struct MenuBarView: View {
+    @ObservedObject var client: PacketEngine
+    @ObservedObject var settings: AppSettingsStore
+    @ObservedObject var inspectionRouter: PacketInspectionRouter
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            statusSection
+            Divider()
+            Button("Open AXTerm") {
+                openMainWindow()
+            }
+
+            Button(connectionActionTitle) {
+                toggleConnection()
+            }
+            .keyboardShortcut("k", modifiers: [.command])
+
+            Button("Preferences…") {
+                openPreferences()
+            }
+            Divider()
+
+            if !recentPackets.isEmpty {
+                Menu("Recent Packets") {
+                    ForEach(recentPackets) { packet in
+                        Button(action: {
+                            inspectionRouter.requestOpenPacket(id: packet.id)
+                        }) {
+                            Text("\(packet.fromDisplay) → \(packet.toDisplay) • \(packet.infoPreview)")
+                        }
+                    }
+                }
+                Divider()
+            }
+
+            Button("Quit AXTerm") {
+                NSApp.terminate(nil)
+            }
+        }
+        .onChange(of: inspectionRouter.shouldOpenMainWindow) { _, shouldOpen in
+            guard shouldOpen else { return }
+            openMainWindow()
+            inspectionRouter.consumeOpenWindowRequest()
+        }
+    }
+
+    private var statusSection: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(statusTitle)
+                .font(.headline)
+            Text("\(connectionDetail) • \(client.packets.count) packets")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 4)
+    }
+
+    private var statusTitle: String {
+        switch client.status {
+        case .connected:
+            return "Connected"
+        case .connecting:
+            return "Connecting"
+        case .disconnected:
+            return "Disconnected"
+        case .failed:
+            return "Connection Failed"
+        }
+    }
+
+    private var connectionDetail: String {
+        let host = client.connectedHost ?? settings.host
+        let port = client.connectedPort.map(String.init) ?? settings.port
+        return "\(host):\(port)"
+    }
+
+    private var connectionActionTitle: String {
+        switch client.status {
+        case .connected, .connecting:
+            return "Disconnect"
+        case .disconnected, .failed:
+            return "Connect"
+        }
+    }
+
+    private var recentPackets: [Packet] {
+        Array(client.packets.suffix(10)).reversed()
+    }
+
+    private func toggleConnection() {
+        switch client.status {
+        case .connected, .connecting:
+            client.disconnect()
+        case .disconnected, .failed:
+            client.connect(host: settings.host, port: settings.portValue)
+        }
+    }
+
+    private func openMainWindow() {
+        openWindow(id: "main")
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    private func openPreferences() {
+        NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+}
+
+#Preview {
+    MenuBarView(
+        client: PacketEngine(settings: AppSettingsStore()),
+        settings: AppSettingsStore(),
+        inspectionRouter: PacketInspectionRouter()
+    )
+}

--- a/AXTerm/Notifications.swift
+++ b/AXTerm/Notifications.swift
@@ -1,0 +1,185 @@
+//
+//  Notifications.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 2/4/26.
+//
+
+import Foundation
+import UserNotifications
+import AppKit
+
+enum NotificationAction {
+    static let watchCategory = "WATCH_HIT"
+    static let openPacket = "OPEN_PACKET"
+    static let openApp = "OPEN_AXTERM"
+    static let packetIDKey = "packetID"
+}
+
+protocol AppStateProviding {
+    var isFrontmost: Bool { get }
+}
+
+struct DefaultAppStateProvider: AppStateProviding {
+    var isFrontmost: Bool {
+        NSApp.isActive
+    }
+}
+
+protocol NotificationCenterScheduling {
+    func add(_ request: UNNotificationRequest)
+}
+
+extension UNUserNotificationCenter: NotificationCenterScheduling {
+    func add(_ request: UNNotificationRequest) {
+        add(request, withCompletionHandler: { _ in })
+    }
+}
+
+final class UserNotificationScheduler: NotificationScheduling {
+    private let center: NotificationCenterScheduling
+    private let settings: AppSettingsStore
+    private let appState: AppStateProviding
+
+    init(
+        center: NotificationCenterScheduling = UNUserNotificationCenter.current(),
+        settings: AppSettingsStore,
+        appState: AppStateProviding
+    ) {
+        self.center = center
+        self.settings = settings
+        self.appState = appState
+    }
+
+    func scheduleWatchNotification(packet: Packet, match: WatchMatch) {
+        guard settings.notifyOnWatchHits else { return }
+        if settings.notifyOnlyWhenInactive && appState.isFrontmost {
+            return
+        }
+
+        let content = UNMutableNotificationContent()
+        content.title = "Watch hit: \(packet.fromDisplay) → \(packet.toDisplay)"
+        content.body = packet.infoPreview.isEmpty ? "Packet received" : packet.infoPreview
+        content.categoryIdentifier = NotificationAction.watchCategory
+        content.userInfo = [NotificationAction.packetIDKey: packet.id.uuidString]
+        if settings.notifyPlaySound {
+            content.sound = .default
+        }
+
+        let request = UNNotificationRequest(
+            identifier: packet.id.uuidString,
+            content: content,
+            trigger: nil
+        )
+
+        center.add(request)
+    }
+}
+
+final class NotificationAuthorizationManager {
+    private let center: UNUserNotificationCenter
+
+    init(center: UNUserNotificationCenter = .current()) {
+        self.center = center
+        configureCategories()
+    }
+
+    func requestAuthorization() async -> Bool {
+        do {
+            let granted = try await center.requestAuthorization(options: [.alert, .sound, .badge])
+            return granted
+        } catch {
+            return false
+        }
+    }
+
+    func sendTestNotification() {
+        let content = UNMutableNotificationContent()
+        content.title = "AXTerm Test"
+        content.body = "Notifications are enabled."
+        content.categoryIdentifier = NotificationAction.watchCategory
+        content.sound = .default
+        let request = UNNotificationRequest(
+            identifier: UUID().uuidString,
+            content: content,
+            trigger: nil
+        )
+        center.add(request) { _ in }
+    }
+
+    private func configureCategories() {
+        let openPacket = UNNotificationAction(
+            identifier: NotificationAction.openPacket,
+            title: "Open Packet",
+            options: [.foreground]
+        )
+        let openApp = UNNotificationAction(
+            identifier: NotificationAction.openApp,
+            title: "Open AXTerm",
+            options: [.foreground]
+        )
+        let category = UNNotificationCategory(
+            identifier: NotificationAction.watchCategory,
+            actions: [openPacket, openApp],
+            intentIdentifiers: [],
+            options: []
+        )
+        center.setNotificationCategories([category])
+    }
+}
+
+@MainActor
+final class PacketInspectionRouter: ObservableObject {
+    @Published private(set) var requestedPacketID: Packet.ID?
+    @Published private(set) var shouldOpenMainWindow = false
+
+    func requestOpenMainWindow() {
+        shouldOpenMainWindow = true
+    }
+
+    func requestOpenPacket(id: Packet.ID) {
+        requestedPacketID = id
+        shouldOpenMainWindow = true
+    }
+
+    func consumeOpenWindowRequest() {
+        shouldOpenMainWindow = false
+    }
+
+    func consumePacketRequest() {
+        requestedPacketID = nil
+    }
+}
+
+final class NotificationActionHandler: NSObject, UNUserNotificationCenterDelegate {
+    private let router: PacketInspectionRouter
+
+    init(router: PacketInspectionRouter) {
+        self.router = router
+        super.init()
+    }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        Task { @MainActor [router] in
+            let userInfo = response.notification.request.content.userInfo
+            let packetIDString = userInfo[NotificationAction.packetIDKey] as? String
+            let packetID = packetIDString.flatMap(UUID.init)
+
+            switch response.actionIdentifier {
+            case NotificationAction.openPacket:
+                if let packetID {
+                    router.requestOpenPacket(id: packetID)
+                } else {
+                    router.requestOpenMainWindow()
+                }
+            default:
+                router.requestOpenMainWindow()
+            }
+            completionHandler()
+        }
+    }
+}

--- a/AXTerm/Persistence/AppEventRecord.swift
+++ b/AXTerm/Persistence/AppEventRecord.swift
@@ -24,6 +24,7 @@ struct AppEventRecord: Codable, FetchableRecord, PersistableRecord, Hashable, Id
         case ui
         case settings
         case packet
+        case watch
     }
 
     var id: UUID

--- a/AXTerm/WatchRules.swift
+++ b/AXTerm/WatchRules.swift
@@ -1,0 +1,118 @@
+//
+//  WatchRules.swift
+//  AXTerm
+//
+//  Created by Ross Wardrup on 2/4/26.
+//
+
+import Foundation
+
+struct WatchMatch: Equatable {
+    let matchedCallsigns: [String]
+    let matchedKeywords: [String]
+
+    var hasMatches: Bool {
+        !matchedCallsigns.isEmpty || !matchedKeywords.isEmpty
+    }
+}
+
+protocol WatchMatching {
+    func match(packet: Packet) -> WatchMatch
+}
+
+final class WatchRuleMatcher: WatchMatching {
+    private let settings: AppSettingsStore
+
+    init(settings: AppSettingsStore) {
+        self.settings = settings
+    }
+
+    func match(packet: Packet) -> WatchMatch {
+        let callsignHits = matchCallsigns(packet: packet)
+        let keywordHits = matchKeywords(packet: packet)
+        return WatchMatch(matchedCallsigns: callsignHits, matchedKeywords: keywordHits)
+    }
+
+    private func matchCallsigns(packet: Packet) -> [String] {
+        let watch = normalizedCallsigns(from: settings.watchCallsigns)
+        guard !watch.isEmpty else { return [] }
+        let tokens = packetCallsignTokens(packet: packet)
+        return watch.filter { tokens.contains($0) }
+    }
+
+    private func matchKeywords(packet: Packet) -> [String] {
+        let watch = normalizedKeywords(from: settings.watchKeywords)
+        guard !watch.isEmpty else { return [] }
+        let payload = (packet.infoText ?? packet.asciiPayload).lowercased()
+        guard !payload.isEmpty else { return [] }
+        return watch.filter { payload.contains($0.lowercased()) }
+    }
+
+    private func packetCallsignTokens(packet: Packet) -> Set<String> {
+        var tokens = Set<String>()
+        if let from = packet.from?.display {
+            tokens.insert(from)
+        }
+        if let to = packet.to?.display {
+            tokens.insert(to)
+        }
+        for address in packet.via {
+            tokens.insert(address.display)
+        }
+        return tokens
+    }
+
+    private func normalizedCallsigns(from values: [String]) -> [String] {
+        AppSettingsStore.sanitizeWatchList(values, normalize: CallsignValidator.normalize)
+    }
+
+    private func normalizedKeywords(from values: [String]) -> [String] {
+        AppSettingsStore.sanitizeWatchList(values) { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+    }
+}
+
+protocol WatchEventRecording {
+    func recordWatchHit(packet: Packet, match: WatchMatch)
+}
+
+final class EventLogWatchRecorder: WatchEventRecording {
+    private let store: EventLogStore
+    private let settings: AppSettingsStore
+
+    init(store: EventLogStore, settings: AppSettingsStore) {
+        self.store = store
+        self.settings = settings
+    }
+
+    func recordWatchHit(packet: Packet, match: WatchMatch) {
+        let metadata = [
+            "packetID": packet.id.uuidString,
+            "from": packet.fromDisplay,
+            "to": packet.toDisplay,
+            "callsigns": match.matchedCallsigns.joined(separator: ","),
+            "keywords": match.matchedKeywords.joined(separator: ",")
+        ]
+
+        let entry = AppEventRecord(
+            id: UUID(),
+            createdAt: Date(),
+            level: .info,
+            category: .watch,
+            message: "Watch hit: \(packet.fromDisplay) → \(packet.toDisplay)",
+            metadataJSON: DeterministicJSON.encodeDictionary(metadata)
+        )
+
+        DispatchQueue.global(qos: .utility).async { [store, settings] in
+            do {
+                try store.append(entry)
+                try store.pruneIfNeeded(retentionLimit: settings.eventRetentionLimit)
+            } catch {
+                return
+            }
+        }
+    }
+}
+
+protocol NotificationScheduling {
+    func scheduleWatchNotification(packet: Packet, match: WatchMatch)
+}

--- a/AXTermTests/AppSettingsStoreTests.swift
+++ b/AXTermTests/AppSettingsStoreTests.swift
@@ -32,4 +32,18 @@ final class AppSettingsStoreTests: XCTestCase {
         XCTAssertEqual(AppSettingsStore.sanitizeLogRetention(600_000), AppSettingsStore.maxLogRetention)
         XCTAssertEqual(AppSettingsStore.sanitizeLogRetention(10_000), 10_000)
     }
+
+    func testWatchListSanitizesAndDedupes() {
+        let input = [" n0call ", "N0CALL", "DEST-1", ""]
+        let result = AppSettingsStore.sanitizeWatchList(input, normalize: CallsignValidator.normalize)
+        XCTAssertEqual(result, ["N0CALL", "DEST-1"])
+    }
+
+    func testMyCallsignPersistsUppercased() {
+        let suiteName = "AXTermTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName) ?? .standard
+        let store = AppSettingsStore(defaults: defaults)
+        store.myCallsign = "n0call-7"
+        XCTAssertEqual(store.myCallsign, "N0CALL-7")
+    }
 }

--- a/AXTermTests/CallsignValidatorTests.swift
+++ b/AXTermTests/CallsignValidatorTests.swift
@@ -1,0 +1,22 @@
+//
+//  CallsignValidatorTests.swift
+//  AXTermTests
+//
+//  Created by Ross Wardrup on 2/4/26.
+//
+
+import XCTest
+@testable import AXTerm
+
+final class CallsignValidatorTests: XCTestCase {
+    func testCallsignValidationAcceptsStandardFormats() {
+        XCTAssertTrue(CallsignValidator.isValid("N0CALL"))
+        XCTAssertTrue(CallsignValidator.isValid("n0call-7"))
+        XCTAssertFalse(CallsignValidator.isValid("1234"))
+        XCTAssertFalse(CallsignValidator.isValid("N0CALL-123"))
+    }
+
+    func testCallsignNormalizationUppercases() {
+        XCTAssertEqual(CallsignValidator.normalize(" n0call-7 "), "N0CALL-7")
+    }
+}

--- a/AXTermTests/MockNotifications.swift
+++ b/AXTermTests/MockNotifications.swift
@@ -1,0 +1,32 @@
+//
+//  MockNotifications.swift
+//  AXTermTests
+//
+//  Created by Ross Wardrup on 2/4/26.
+//
+
+import Foundation
+import UserNotifications
+@testable import AXTerm
+
+final class MockNotificationScheduler: NotificationScheduling {
+    private(set) var scheduledPackets: [Packet] = []
+    private(set) var scheduledMatches: [WatchMatch] = []
+
+    func scheduleWatchNotification(packet: Packet, match: WatchMatch) {
+        scheduledPackets.append(packet)
+        scheduledMatches.append(match)
+    }
+}
+
+final class MockNotificationCenter: NotificationCenterScheduling {
+    private(set) var requests: [UNNotificationRequest] = []
+
+    func add(_ request: UNNotificationRequest) {
+        requests.append(request)
+    }
+}
+
+struct MockAppState: AppStateProviding {
+    var isFrontmost: Bool
+}

--- a/AXTermTests/PacketHandlingTests.swift
+++ b/AXTermTests/PacketHandlingTests.swift
@@ -16,7 +16,7 @@ final class PacketHandlingTests: XCTestCase {
         let consoleStore = MockConsoleStore()
         let rawStore = MockRawStore()
         let eventLogger = MockEventLogger()
-        let client = KISSTcpClient(
+        let client = PacketEngine(
             maxPackets: 10,
             maxConsoleLines: 10,
             maxRawChunks: 10,
@@ -56,7 +56,7 @@ final class PacketHandlingTests: XCTestCase {
         let store = MockPacketStore()
         let consoleStore = MockConsoleStore()
         let rawStore = MockRawStore()
-        let client = KISSTcpClient(
+        let client = PacketEngine(
             maxPackets: 10,
             maxConsoleLines: 10,
             maxRawChunks: 10,
@@ -90,7 +90,7 @@ final class PacketHandlingTests: XCTestCase {
     func testConnectInvalidPortLogsEvent() {
         let settings = makeSettings(persistHistory: true)
         let eventLogger = MockEventLogger()
-        let client = KISSTcpClient(
+        let client = PacketEngine(
             maxPackets: 1,
             maxConsoleLines: 1,
             maxRawChunks: 1,
@@ -104,6 +104,17 @@ final class PacketHandlingTests: XCTestCase {
         client.connect(host: "localhost", port: 0)
 
         XCTAssertTrue(eventLogger.entries.contains(where: { $0.0 == .error && $0.1 == .connection }))
+    }
+
+    func testConnectDisconnectUpdatesStatus() {
+        let settings = makeSettings(persistHistory: true)
+        let client = PacketEngine(settings: settings)
+
+        client.connect(host: "localhost", port: 8001)
+        XCTAssertEqual(client.status, .connecting)
+
+        client.disconnect()
+        XCTAssertEqual(client.status, .disconnected)
     }
 
     private func makeSettings(persistHistory: Bool) -> AppSettingsStore {

--- a/AXTermTests/WatchNotificationIntegrationTests.swift
+++ b/AXTermTests/WatchNotificationIntegrationTests.swift
@@ -1,0 +1,52 @@
+//
+//  WatchNotificationIntegrationTests.swift
+//  AXTermTests
+//
+//  Created by Ross Wardrup on 2/4/26.
+//
+
+import XCTest
+@testable import AXTerm
+
+@MainActor
+final class WatchNotificationIntegrationTests: XCTestCase {
+    func testWatchHitPersistsEventAndSchedulesNotification() async {
+        let settings = makeSettings()
+        settings.watchCallsigns = ["N0CALL"]
+        let eventStore = MockEventLogStore()
+        let watchRecorder = EventLogWatchRecorder(store: eventStore, settings: settings)
+        let scheduler = MockNotificationScheduler()
+        let engine = PacketEngine(
+            settings: settings,
+            packetStore: nil,
+            consoleStore: nil,
+            rawStore: nil,
+            eventLogger: nil,
+            watchRecorder: watchRecorder,
+            notificationScheduler: scheduler
+        )
+
+        let packet = Packet(from: AX25Address(call: "N0CALL"), to: AX25Address(call: "DEST"))
+        engine.handleIncomingPacket(packet)
+
+        await waitForEventStore(eventStore)
+
+        XCTAssertEqual(eventStore.appendedEntries.count, 1)
+        XCTAssertEqual(scheduler.scheduledPackets.count, 1)
+    }
+
+    private func makeSettings() -> AppSettingsStore {
+        let suiteName = "AXTermTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName) ?? .standard
+        return AppSettingsStore(defaults: defaults)
+    }
+
+    private func waitForEventStore(_ store: MockEventLogStore) async {
+        for _ in 0..<10 {
+            if !store.appendedEntries.isEmpty {
+                return
+            }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+    }
+}

--- a/AXTermTests/WatchRulesTests.swift
+++ b/AXTermTests/WatchRulesTests.swift
@@ -1,0 +1,75 @@
+//
+//  WatchRulesTests.swift
+//  AXTermTests
+//
+//  Created by Ross Wardrup on 2/4/26.
+//
+
+import XCTest
+@testable import AXTerm
+
+final class WatchRulesTests: XCTestCase {
+    func testCallsignMatchesFromToVia() {
+        let settings = makeSettings()
+        settings.watchCallsigns = ["N0CALL", "WIDE1-1"]
+        let matcher = WatchRuleMatcher(settings: settings)
+
+        let packet = Packet(
+            from: AX25Address(call: "N0CALL"),
+            to: AX25Address(call: "DEST"),
+            via: [AX25Address(call: "WIDE1", ssid: 1)]
+        )
+
+        let match = matcher.match(packet: packet)
+        XCTAssertEqual(match.matchedCallsigns, ["N0CALL", "WIDE1-1"])
+        XCTAssertTrue(match.matchedKeywords.isEmpty)
+    }
+
+    func testKeywordMatchesPayload() {
+        let settings = makeSettings()
+        settings.watchKeywords = ["storm", "qrp"]
+        let matcher = WatchRuleMatcher(settings: settings)
+
+        let packet = Packet(info: Data("Storm warning at 7pm".utf8))
+        let match = matcher.match(packet: packet)
+
+        XCTAssertEqual(match.matchedKeywords, ["storm"])
+        XCTAssertTrue(match.matchedCallsigns.isEmpty)
+    }
+
+    func testNotificationHonorsFrontmostRule() {
+        let settings = makeSettings()
+        settings.notifyOnWatchHits = true
+        settings.notifyOnlyWhenInactive = true
+        let center = MockNotificationCenter()
+        let appState = MockAppState(isFrontmost: true)
+        let scheduler = UserNotificationScheduler(center: center, settings: settings, appState: appState)
+
+        let packet = Packet(from: AX25Address(call: "N0CALL"), info: Data("Test".utf8))
+        let match = WatchMatch(matchedCallsigns: ["N0CALL"], matchedKeywords: [])
+        scheduler.scheduleWatchNotification(packet: packet, match: match)
+
+        XCTAssertTrue(center.requests.isEmpty)
+    }
+
+    func testNotificationSchedulesWhenBackgrounded() {
+        let settings = makeSettings()
+        settings.notifyOnWatchHits = true
+        settings.notifyOnlyWhenInactive = true
+        let center = MockNotificationCenter()
+        let appState = MockAppState(isFrontmost: false)
+        let scheduler = UserNotificationScheduler(center: center, settings: settings, appState: appState)
+
+        let packet = Packet(from: AX25Address(call: "N0CALL"), info: Data("Test".utf8))
+        let match = WatchMatch(matchedCallsigns: ["N0CALL"], matchedKeywords: [])
+        scheduler.scheduleWatchNotification(packet: packet, match: match)
+
+        XCTAssertEqual(center.requests.count, 1)
+    }
+
+    private func makeSettings() -> AppSettingsStore {
+        let suiteName = "AXTermTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName) ?? .standard
+        return AppSettingsStore(defaults: defaults)
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide an optional menu-bar monitoring mode so AXTerm can run headless while still monitoring Direwolf and delivering timely alerts. 
- Let users declare a personal callsign and watch lists (callsigns and keywords) to trigger persisted watch events and native macOS notifications. 
- Reuse the existing receive pipeline and persistence; surface watch matches from the same shared engine instance used by the window UI. 

### Description
- Introduced a shared `PacketEngine` (renamed from `KISSTcpClient`) that owns KISS connection lifecycle, decode/persist pipeline, and now invokes watch matching, event recording, and notification scheduling; watch hooks are injectable via protocols (`WatchMatching`, `WatchEventRecording`, `NotificationScheduling`).
- Added watch rule engine and recorder in `AXTerm/WatchRules.swift` and a notification subsystem in `AXTerm/Notifications.swift` (including `UserNotificationScheduler`, `NotificationAuthorizationManager`, `NotificationActionHandler` and a `PacketInspectionRouter` to route "Open Packet" actions into the app).
- Implemented menu bar mode and UI: `MenuBarExtra` in `AXTermApp.swift` plus `AXTerm/AXTermAppDelegate.swift` and `AXTerm/MenuBarView.swift`, ensuring the app can remain running with zero windows when `settings.runInMenuBar` is enabled and exposing quick actions and recent packets.
- Added settings: `My Callsign`, watch callsigns/keywords, toggles for `Run in menu bar`, `Launch at login` (using `SMAppService`), `Auto-connect on launch`, and notification controls; settings live in `AXTerm/Settings/AppSettingsStore.swift` and UI in `AXTerm/Settings/SettingsView.swift`.
- Added small utilities and validation: `AXTerm/CallsignValidator.swift` and normalization/sanitization for watch lists; `AppSettingsStore` persistence keys and helpers updated.
- Wire-up: `AXTermApp` creates and injects `PacketEngine`, `EventLogWatchRecorder`, `UserNotificationScheduler` and `NotificationActionHandler` so menu-bar UI and main windows share the same engine and routing for notification actions opens the main window and the packet inspector.

### Testing
- Added automated XCTest coverage: `WatchRulesTests`, `WatchNotificationIntegrationTests`, `CallsignValidatorTests`, and updates to `AppSettingsStoreTests` and `PacketHandlingTests` covering callsign validation, watch matching (from/to/via), notification scheduling policy, event recording on watch hits, settings sanitization, and basic engine lifecycle methods.
- Attempted to run the test suite with `xcodebuild -scheme AXTerm -destination 'platform=macOS' test` but the environment lacks `xcodebuild` so tests were not executed here; tests are added and should run in CI or a macOS dev environment with Xcode available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697aa48394e88330be01350d47621fc1)