### PR TITLE
Avoid depending on `SpanStatus` when finishing Sentry span

### DIFF
--- a/AXTerm/Observability/Sentry/SentryManager.swift
+++ b/AXTerm/Observability/Sentry/SentryManager.swift
@@ -276,10 +276,10 @@ final class SentryManager {
     }
 
     /// Finish a performance transaction.
-    func finishTransaction(_ transaction: Any?, status: String = "ok") {
+    func finishTransaction(_ transaction: Any?, status _: String = "ok") {
         #if canImport(Sentry)
         guard let span = transaction as? Span else { return }
-        span.finish(status: SpanStatus(rawValue: status) ?? .ok)
+        span.finish()
         #endif
     }
 
@@ -496,4 +496,3 @@ final class SentryManager {
     }
     #endif
 }
-


### PR DESCRIPTION
### Motivation
- The code referenced `SpanStatus` when finishing Sentry spans which can break builds for SDK variants that don't expose that type, so the finish path needs to be SDK-agnostic.

### Description
- Update `finishTransaction` in `AXTerm/Observability/Sentry/SentryManager.swift` to mark the `status` parameter unused and call `span.finish()` instead of `span.finish(status: SpanStatus(rawValue: status) ?? .ok)` to avoid the `SpanStatus` dependency.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ac4b974a883309e71ed9423dc9a9f)