### PR TITLE
Fix flaky row selection in packets Table (improve hit-testing)

### DIFF
--- a/AXTerm/PacketTableView.swift
+++ b/AXTerm/PacketTableView.swift
@@ -157,9 +157,7 @@ private struct PacketTableCell<Content: View>: View {
         content
             .frame(maxWidth: .infinity, alignment: alignment)
             .contentShape(Rectangle())
-            .background(RowSelectionCaptureView {
-                selection = [packet.id]
-            })
+            .background(debugHitTestOverlay)
             .contextMenu {
                 Button("Inspect Packet") {
                     selection = [packet.id]
@@ -177,9 +175,23 @@ private struct PacketTableCell<Content: View>: View {
                     onCopyRawHex(packet)
                 }
             }
-            .onTapGesture(count: 2) {
+            .simultaneousGesture(TapGesture(count: 2).onEnded {
                 selection = [packet.id]
                 onInspectSelection()
-            }
+            })
     }
+
+    @ViewBuilder
+    private var debugHitTestOverlay: some View {
+        if Self.debugHitTesting {
+            Rectangle()
+                .strokeBorder(.pink.opacity(0.6), lineWidth: 1)
+                .background(Color.pink.opacity(0.1))
+                .allowsHitTesting(false)
+        } else {
+            EmptyView()
+        }
+    }
+
+    private static let debugHitTesting = false
 }

--- a/AXTermTests/PacketSelectionResolverTests.swift
+++ b/AXTermTests/PacketSelectionResolverTests.swift
@@ -51,4 +51,32 @@ final class PacketSelectionResolverTests: XCTestCase {
 
         XCTAssertTrue(filtered.isEmpty)
     }
+
+    func testFilteredSelectionPreservesSelectionWhenPacketsGrow() {
+        let selectedID = UUID()
+        let initialPackets = [
+            Packet(id: selectedID, from: AX25Address(call: "N0CALL"))
+        ]
+        let selection: Set<Packet.ID> = [selectedID]
+        let expandedPackets = initialPackets + [Packet(id: UUID(), from: AX25Address(call: "W0ABC"))]
+
+        let filtered = PacketSelectionResolver.filteredSelection(selection, for: expandedPackets)
+
+        XCTAssertEqual(filtered, selection)
+    }
+
+    func testFilteredSelectionPreservesSelectionWithInsertAtTop() {
+        let selectedID = UUID()
+        let existingPackets = [
+            Packet(id: selectedID, from: AX25Address(call: "N0CALL"))
+        ]
+        let selection: Set<Packet.ID> = [selectedID]
+        let packetsWithInsertion = [
+            Packet(id: UUID(), from: AX25Address(call: "K1ABC"))
+        ] + existingPackets
+
+        let filtered = PacketSelectionResolver.filteredSelection(selection, for: packetsWithInsertion)
+
+        XCTAssertEqual(filtered, selection)
+    }
 }


### PR DESCRIPTION
### Motivation
- Row clicks were unreliable because a custom NSView-based capture layer and competing gestures could intercept hit testing and interfere with Table selection and single-click behavior.
- Keep double-click activation for inspector and context-menu actions while ensuring whole-row clicks select consistently.
- Add unit coverage to prevent regressions when packets are inserted or appended (selection should persist).

### Description
- Replaced the NSView-backed click capture background with a non-interactive debug overlay and removed the background view that intercepted hits, by updating `PacketTableView.PacketTableCell` in `PacketTableView.swift` so the cell uses the existing `contentShape(Rectangle())` plus a `debugHitTestOverlay` toggle.  This preserves visuals while ensuring the row surface is fully hittable.
- Replaced `.onTapGesture(count: 2)` with a `simultaneousGesture(TapGesture(count: 2).onEnded { ... })` to avoid gesture priority conflicts with single-click selection while preserving double-click inspector activation. (`PacketTableView.swift`)
- Added two deterministic unit tests to `PacketSelectionResolverTests.swift` to assert that selection is preserved when packets are appended and when a packet is inserted at the top, preventing regressions when packet lists grow or receive inserts.
- Changes are minimal and avoid forced unwraps or breaking accessibility/keyboard navigation.

### Testing
- Added unit tests: `testFilteredSelectionPreservesSelectionWhenPacketsGrow` and `testFilteredSelectionPreservesSelectionWithInsertAtTop` in `AXTermTests/PacketSelectionResolverTests.swift` (unit tests only; they exercise `PacketSelectionResolver.filteredSelection`).
- Attempted to run the test suite with `xcodebuild -project AXTerm.xcodeproj -scheme AXTermTests -destination 'platform=macOS' test`, but `xcodebuild` is not available in the current environment so tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ac7260d808330a1dcd4b799eb876a)