### PR TITLE
Fix PacketTableView debug overlay duplication

### DIFF
--- a/AXTerm/PacketTableView.swift
+++ b/AXTerm/PacketTableView.swift
@@ -195,17 +195,5 @@ private struct PacketTableCell<Content: View>: View {
         }
     }
 
-    @ViewBuilder
-    private var debugHitTestOverlay: some View {
-        if Self.debugHitTesting {
-            Rectangle()
-                .strokeBorder(.pink.opacity(0.6), lineWidth: 1)
-                .background(Color.pink.opacity(0.1))
-                .allowsHitTesting(false)
-        } else {
-            EmptyView()
-        }
-    }
-
-    private static let debugHitTesting = false
+    
 }


### PR DESCRIPTION
### Motivation
- Remove duplicated `debugHitTestOverlay` view and `debugHitTesting` static flag that caused a redundant declaration and could lead to build errors, and consolidate to the shared hit-testing toggle.

### Description
- Deleted the duplicated `@ViewBuilder private var debugHitTestOverlay` and `private static let debugHitTesting` from `AXTerm/PacketTableView.swift` so `PacketTableCell` now relies on the top-level `packetTableDebugHitTesting` constant.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ac8c15f748330822d5fa7cc899ca0)