### PR TITLE
Replace AppKit settings selector with SwiftUI `openSettings` and add `SettingsLink()`

### DIFF
--- a/AXTerm/AXTermApp.swift
+++ b/AXTerm/AXTermApp.swift
@@ -72,6 +72,9 @@ struct AXTermApp: App {
             ContentView(client: client, settings: settings, inspectionRouter: inspectionRouter)
         }
         .commands {
+            CommandGroup(replacing: .appSettings) {
+                SettingsLink()
+            }
             CommandGroup(after: .windowArrangement) {
                 Button("Close") {
                     NSApp.keyWindow?.performClose(nil)

--- a/AXTerm/MenuBarView.swift
+++ b/AXTerm/MenuBarView.swift
@@ -12,6 +12,7 @@ struct MenuBarView: View {
     @ObservedObject var settings: AppSettingsStore
     @ObservedObject var inspectionRouter: PacketInspectionRouter
     @Environment(\.openWindow) private var openWindow
+    @Environment(\.openSettings) private var openSettings
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -120,7 +121,7 @@ struct MenuBarView: View {
     }
 
     private func openPreferences() {
-        NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+        openSettings()
         NSApp.activate(ignoringOtherApps: true)
     }
 }


### PR DESCRIPTION
### Motivation
- Remove AppKit selector usage `showSettingsWindow:` and adopt SwiftUI's built-in settings entrypoints so the app uses `openSettings()` and the app menu exposes the proper Settings item and shortcut.

### Description
- Replace `NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)` with SwiftUI environment `openSettings()` in `MenuBarView.swift` and add `@Environment(\.openSettings) private var openSettings` so the menu-bar Preferences button calls `openSettings()`.
- Add a `CommandGroup(replacing: .appSettings)` containing `SettingsLink()` in `AXTermApp.swift` so the app menu shows the Settings… item and the Cmd+, shortcut is available.
- Remove the project occurrence(s) of `showSettingsWindow:` (search confirmed no remaining matches).

### Testing
- Performed a project-wide search for `showSettingsWindow` and confirmed the occurrence was removed and no other matches remain.
- Verified files were updated and staged; changes were committed successfully; no automated unit or UI tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b4658466083308fb2cdc1aacda288)