### PR TITLE
Add analytics model layer, normalization, summary engine, and telemetry wrapper

### DIFF
--- a/AXTerm/Analytics/AnalyticsEngine.swift
+++ b/AXTerm/Analytics/AnalyticsEngine.swift
@@ -1,0 +1,101 @@
+//
+//  AnalyticsEngine.swift
+//  AXTerm
+//
+//  Created by AXTerm on 2026-02-18.
+//
+
+import Foundation
+
+enum AnalyticsEngine {
+    static func normalizePackets(_ packets: [Packet]) -> [PacketEvent] {
+        packets.map { PacketEvent(packet: $0) }
+    }
+
+    static func uniqueStationsCount(packets: [Packet], includeViaInUniqueStations: Bool = true) -> Int {
+        let events = normalizePackets(packets)
+        return uniqueStationsCount(events: events, includeViaInUniqueStations: includeViaInUniqueStations)
+    }
+
+    static func computeSummary(
+        packets: [Packet],
+        includeViaInUniqueStations: Bool = true,
+        topLimit: Int = 5
+    ) -> AnalyticsSummary {
+        let events = normalizePackets(packets)
+        return computeSummary(
+            events: events,
+            includeViaInUniqueStations: includeViaInUniqueStations,
+            topLimit: topLimit
+        )
+    }
+
+    private static func computeSummary(
+        events: [PacketEvent],
+        includeViaInUniqueStations: Bool,
+        topLimit: Int
+    ) -> AnalyticsSummary {
+        let packetCount = events.count
+        let totalPayloadBytes = events.reduce(0) { $0 + $1.payloadBytes }
+        let infoTextCount = events.reduce(0) { $1.infoTextPresent ? $0 + 1 : $0 }
+        let infoTextRatio = packetCount > 0 ? Double(infoTextCount) / Double(packetCount) : 0
+
+        var frameTypeCounts: [FrameType: Int] = [:]
+        frameTypeCounts.reserveCapacity(FrameType.allCases.count)
+        events.forEach { event in
+            frameTypeCounts[event.frameType, default: 0] += 1
+        }
+
+        let uniqueStationsCount = uniqueStationsCount(events: events, includeViaInUniqueStations: includeViaInUniqueStations)
+
+        let topTalkersByFrom = topStations(from: events.compactMap { $0.from }, limit: topLimit)
+        let topDestinationsByTo = topStations(from: events.compactMap { $0.to }, limit: topLimit)
+
+        return AnalyticsSummary(
+            packetCount: packetCount,
+            uniqueStationsCount: uniqueStationsCount,
+            topTalkersByFrom: topTalkersByFrom,
+            topDestinationsByTo: topDestinationsByTo,
+            frameTypeCounts: frameTypeCounts,
+            infoTextRatio: infoTextRatio,
+            totalPayloadBytes: totalPayloadBytes
+        )
+    }
+
+    private static func uniqueStationsCount(
+        events: [PacketEvent],
+        includeViaInUniqueStations: Bool
+    ) -> Int {
+        var uniqueStations: Set<String> = []
+        events.forEach { event in
+            if let from = event.from {
+                uniqueStations.insert(from)
+            }
+            if let to = event.to {
+                uniqueStations.insert(to)
+            }
+            if includeViaInUniqueStations {
+                event.via.forEach { uniqueStations.insert($0) }
+            }
+        }
+        return uniqueStations.count
+    }
+
+    private static func topStations(from stations: [String], limit: Int) -> [StationCount] {
+        guard limit > 0 else { return [] }
+        var counts: [String: Int] = [:]
+        stations.forEach { station in
+            counts[station, default: 0] += 1
+        }
+        return counts
+            .map { StationCount(station: $0.key, count: $0.value) }
+            .sorted { lhs, rhs in
+                if lhs.count == rhs.count {
+                    return lhs.station < rhs.station
+                }
+                return lhs.count > rhs.count
+            }
+            .prefix(limit)
+            .map { $0 }
+    }
+}

--- a/AXTerm/Analytics/AnalyticsSummary.swift
+++ b/AXTerm/Analytics/AnalyticsSummary.swift
@@ -1,0 +1,23 @@
+//
+//  AnalyticsSummary.swift
+//  AXTerm
+//
+//  Created by AXTerm on 2026-02-18.
+//
+
+import Foundation
+
+struct StationCount: Hashable, Sendable {
+    let station: String
+    let count: Int
+}
+
+struct AnalyticsSummary: Hashable, Sendable {
+    let packetCount: Int
+    let uniqueStationsCount: Int
+    let topTalkersByFrom: [StationCount]
+    let topDestinationsByTo: [StationCount]
+    let frameTypeCounts: [FrameType: Int]
+    let infoTextRatio: Double
+    let totalPayloadBytes: Int
+}

--- a/AXTerm/Analytics/PacketEvent.swift
+++ b/AXTerm/Analytics/PacketEvent.swift
@@ -1,0 +1,28 @@
+//
+//  PacketEvent.swift
+//  AXTerm
+//
+//  Created by AXTerm on 2026-02-18.
+//
+
+import Foundation
+
+struct PacketEvent: Hashable, Sendable {
+    let timestamp: Date
+    let from: String?
+    let to: String?
+    let via: [String]
+    let frameType: FrameType
+    let infoTextPresent: Bool
+    let payloadBytes: Int
+
+    init(packet: Packet) {
+        timestamp = packet.timestamp
+        from = StationNormalizer.normalize(packet.fromDisplay)
+        to = StationNormalizer.normalize(packet.toDisplay)
+        via = packet.via.compactMap { StationNormalizer.normalize($0.display) }
+        frameType = packet.frameType
+        infoTextPresent = packet.infoText?.isEmpty == false
+        payloadBytes = packet.info.count
+    }
+}

--- a/AXTerm/Analytics/StationNormalizer.swift
+++ b/AXTerm/Analytics/StationNormalizer.swift
@@ -1,0 +1,17 @@
+//
+//  StationNormalizer.swift
+//  AXTerm
+//
+//  Created by AXTerm on 2026-02-18.
+//
+
+import Foundation
+
+enum StationNormalizer {
+    static func normalize(_ station: String?) -> String? {
+        guard let station else { return nil }
+        let trimmed = station.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed != "?" else { return nil }
+        return trimmed.uppercased()
+    }
+}

--- a/AXTermTests/AnalyticsEngineTests.swift
+++ b/AXTermTests/AnalyticsEngineTests.swift
@@ -1,0 +1,97 @@
+//
+//  AnalyticsEngineTests.swift
+//  AXTermTests
+//
+//  Created by AXTerm on 2026-02-18.
+//
+
+import XCTest
+@testable import AXTerm
+
+final class AnalyticsEngineTests: XCTestCase {
+    func testComputeSummaryCountsAndTopLists() {
+        let packet1 = Packet(
+            timestamp: Date(),
+            from: AX25Address(call: "n0call", ssid: 1),
+            to: AX25Address(call: "dest"),
+            via: [AX25Address(call: "dig1")],
+            frameType: .ui,
+            info: Data([0x41, 0x42])
+        )
+        let packet2 = Packet(
+            timestamp: Date(),
+            from: nil,
+            to: AX25Address(call: "dest"),
+            via: [],
+            frameType: .i,
+            info: Data()
+        )
+        let packet3 = Packet(
+            timestamp: Date(),
+            from: AX25Address(call: "n0call", ssid: 1),
+            to: nil,
+            via: [AX25Address(call: "dig2")],
+            frameType: .ui,
+            info: Data([0x00])
+        )
+
+        let summary = AnalyticsEngine.computeSummary(packets: [packet1, packet2, packet3])
+
+        XCTAssertEqual(summary.packetCount, 3)
+        XCTAssertEqual(summary.uniqueStationsCount, 4)
+        XCTAssertEqual(summary.totalPayloadBytes, 3)
+        XCTAssertEqual(summary.infoTextRatio, 1.0 / 3.0, accuracy: 0.0001)
+        XCTAssertEqual(summary.frameTypeCounts[.ui], 2)
+        XCTAssertEqual(summary.frameTypeCounts[.i], 1)
+
+        XCTAssertEqual(summary.topTalkersByFrom, [StationCount(station: "N0CALL-1", count: 2)])
+        XCTAssertEqual(summary.topDestinationsByTo, [StationCount(station: "DEST", count: 2)])
+    }
+
+    func testUniqueStationsExcludeViaWhenConfigured() {
+        let packet = Packet(
+            timestamp: Date(),
+            from: AX25Address(call: "call"),
+            to: AX25Address(call: "dest"),
+            via: [AX25Address(call: "dig1"), AX25Address(call: "dig2")],
+            frameType: .ui,
+            info: Data()
+        )
+
+        let summary = AnalyticsEngine.computeSummary(
+            packets: [packet],
+            includeViaInUniqueStations: false
+        )
+
+        XCTAssertEqual(summary.uniqueStationsCount, 2)
+    }
+
+    func testComputeSummaryWithEmptyPackets() {
+        let summary = AnalyticsEngine.computeSummary(packets: [])
+
+        XCTAssertEqual(summary.packetCount, 0)
+        XCTAssertEqual(summary.uniqueStationsCount, 0)
+        XCTAssertEqual(summary.totalPayloadBytes, 0)
+        XCTAssertEqual(summary.infoTextRatio, 0)
+        XCTAssertTrue(summary.topTalkersByFrom.isEmpty)
+        XCTAssertTrue(summary.topDestinationsByTo.isEmpty)
+    }
+
+    func testAllUnknownStationsExcludedFromTopLists() {
+        let packet = Packet(
+            timestamp: Date(),
+            from: nil,
+            to: nil,
+            via: [],
+            frameType: .unknown,
+            info: Data()
+        )
+
+        let summary = AnalyticsEngine.computeSummary(packets: [packet])
+
+        XCTAssertEqual(summary.packetCount, 1)
+        XCTAssertEqual(summary.uniqueStationsCount, 0)
+        XCTAssertTrue(summary.topTalkersByFrom.isEmpty)
+        XCTAssertTrue(summary.topDestinationsByTo.isEmpty)
+    }
+}

--- a/AXTermTests/StationNormalizerTests.swift
+++ b/AXTermTests/StationNormalizerTests.swift
@@ -1,0 +1,29 @@
+//
+//  StationNormalizerTests.swift
+//  AXTermTests
+//
+//  Created by AXTerm on 2026-02-18.
+//
+
+import XCTest
+@testable import AXTerm
+
+final class StationNormalizerTests: XCTestCase {
+    func testNormalizeNilReturnsNil() {
+        XCTAssertNil(StationNormalizer.normalize(nil))
+    }
+
+    func testNormalizeEmptyReturnsNil() {
+        XCTAssertNil(StationNormalizer.normalize(""))
+        XCTAssertNil(StationNormalizer.normalize("   "))
+    }
+
+    func testNormalizeQuestionMarkReturnsNil() {
+        XCTAssertNil(StationNormalizer.normalize("?"))
+        XCTAssertNil(StationNormalizer.normalize(" ? "))
+    }
+
+    func testNormalizeUppercasesAndTrims() {
+        XCTAssertEqual(StationNormalizer.normalize(" n0call-1 "), "N0CALL-1")
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a pure, testable analytics model that normalizes `Packet` records into a compact `PacketEvent` and computes summary statistics for UI/telemetry use.
- Normalize station identifiers consistently (treat `"?"` and empty as unknown) so downstream aggregation and top-N lists are predictable.
- Add a small orchestration boundary that records telemetry breadcrumbs/spans and captures unexpected invariants without contaminating the pure analytics code.

### Description
- Added new analytics model files: `Analytics/PacketEvent.swift` (maps `Packet` → `PacketEvent`), `Analytics/StationNormalizer.swift` (pure `StationNormalizer.normalize(_:) -> String?` with trimming, `?`/empty → `nil`, uppercasing), `Analytics/AnalyticsSummary.swift` (summary types such as `AnalyticsSummary` and `StationCount`), and `Analytics/AnalyticsEngine.swift` (pure `AnalyticsEngine.computeSummary(packets:includeViaInUniqueStations:topLimit:)` and helpers).
- Implemented summary metrics including `packetCount`, `uniqueStationsCount` (configurable via `includeViaInUniqueStations`), `topTalkersByFrom`, `topDestinationsByTo`, `frameTypeCounts`, `infoTextRatio`, and `totalPayloadBytes`.
- Added `AnalyticsViewModel` (minimal orchestration) in `PacketEngine.swift` that emits a breadcrumb at recompute start, measures `analytics.computeSummary` via `Telemetry.measure`, and captures telemetry if invariants (NaN ratio or negative bytes) occur; no telemetry calls were added to the pure engine.
- Added unit tests: `AXTermTests/StationNormalizerTests.swift` for normalization rules and `AXTermTests/AnalyticsEngineTests.swift` for summary calculation and edge cases.

### Testing
- Added unit tests `StationNormalizerTests` and `AnalyticsEngineTests` covering normalization behavior, top-N exclusion of unknowns, unique station counting with/without `via`, frame type counts, payload/ratio calculations, and empty/unknown-edge cases; these tests were committed but not executed in this rollout.
- No automated tests were run during this change, so test results are undetermined.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b6b659df48330b6d102ddcc695b75)