### PR TITLE
Add time-bucketed analytics series, ViewModel telemetry, and tests

### DIFF
--- a/AXTerm/Analytics/AnalyticsEngine.swift
+++ b/AXTerm/Analytics/AnalyticsEngine.swift
@@ -33,7 +33,8 @@ enum AnalyticsEngine {
     static func computeSeries(
         packets: [Packet],
         bucket: TimeBucket,
-        calendar: Calendar
+        calendar: Calendar,
+        includeViaInUniqueStations: Bool = true
     ) -> AnalyticsSeries {
         guard !packets.isEmpty else { return .empty }
         let events = normalizePackets(packets)
@@ -50,6 +51,11 @@ enum AnalyticsEngine {
             }
             if let to = event.to {
                 uniqueStations[key, default: []].insert(to)
+            }
+            if includeViaInUniqueStations {
+                event.via.forEach { station in
+                    uniqueStations[key, default: []].insert(station)
+                }
             }
         }
 

--- a/AXTerm/Analytics/AnalyticsSeries.swift
+++ b/AXTerm/Analytics/AnalyticsSeries.swift
@@ -1,0 +1,25 @@
+//
+//  AnalyticsSeries.swift
+//  AXTerm
+//
+//  Created by AXTerm on 2026-02-18.
+//
+
+import Foundation
+
+struct AnalyticsSeriesPoint: Hashable, Sendable {
+    let bucket: Date
+    let value: Int
+}
+
+struct AnalyticsSeries: Hashable, Sendable {
+    let packetsPerBucket: [AnalyticsSeriesPoint]
+    let bytesPerBucket: [AnalyticsSeriesPoint]
+    let uniqueStationsPerBucket: [AnalyticsSeriesPoint]
+
+    static let empty = AnalyticsSeries(
+        packetsPerBucket: [],
+        bytesPerBucket: [],
+        uniqueStationsPerBucket: []
+    )
+}

--- a/AXTermTests/AnalyticsSeriesTests.swift
+++ b/AXTermTests/AnalyticsSeriesTests.swift
@@ -1,0 +1,132 @@
+//
+//  AnalyticsSeriesTests.swift
+//  AXTermTests
+//
+//  Created by AXTerm on 2026-02-18.
+//
+
+import XCTest
+@testable import AXTerm
+
+final class AnalyticsSeriesTests: XCTestCase {
+    private var calendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return calendar
+    }
+
+    func testComputeSeriesBucketsAlignToFiveMinuteBoundaries() {
+        let date1 = makeDate(year: 2026, month: 2, day: 18, hour: 6, minute: 0, second: 0)
+        let date2 = makeDate(year: 2026, month: 2, day: 18, hour: 6, minute: 4, second: 59)
+        let date3 = makeDate(year: 2026, month: 2, day: 18, hour: 6, minute: 5, second: 0)
+
+        let packets = [
+            makePacket(timestamp: date1, infoBytes: [0x01]),
+            makePacket(timestamp: date2, infoBytes: [0x02]),
+            makePacket(timestamp: date3, infoBytes: [0x03])
+        ]
+
+        let series = AnalyticsEngine.computeSeries(
+            packets: packets,
+            bucket: .fiveMinutes,
+            calendar: calendar
+        )
+
+        XCTAssertEqual(series.packetsPerBucket.count, 2)
+        XCTAssertEqual(series.packetsPerBucket[0].bucket, date1)
+        XCTAssertEqual(series.packetsPerBucket[0].value, 2)
+        XCTAssertEqual(series.packetsPerBucket[1].bucket, date3)
+        XCTAssertEqual(series.packetsPerBucket[1].value, 1)
+    }
+
+    func testComputeSeriesSortedAndUniqueBuckets() {
+        let date1 = makeDate(year: 2026, month: 2, day: 18, hour: 7, minute: 5, second: 1)
+        let date2 = makeDate(year: 2026, month: 2, day: 18, hour: 7, minute: 15, second: 1)
+
+        let packets = [
+            makePacket(timestamp: date2, infoBytes: [0x01]),
+            makePacket(timestamp: date1, infoBytes: [0x02])
+        ]
+
+        let series = AnalyticsEngine.computeSeries(
+            packets: packets,
+            bucket: .fiveMinutes,
+            calendar: calendar
+        )
+
+        XCTAssertEqual(series.packetsPerBucket.map(\.bucket), [date1, date2])
+        XCTAssertEqual(series.bytesPerBucket.map(\.bucket), [date1, date2])
+        XCTAssertEqual(series.uniqueStationsPerBucket.map(\.bucket), [date1, date2])
+        XCTAssertEqual(Set(series.packetsPerBucket.map(\.bucket)).count, series.packetsPerBucket.count)
+    }
+
+    func testComputeSeriesEmptyInput() {
+        let series = AnalyticsEngine.computeSeries(
+            packets: [],
+            bucket: .hour,
+            calendar: calendar
+        )
+
+        XCTAssertTrue(series.packetsPerBucket.isEmpty)
+        XCTAssertTrue(series.bytesPerBucket.isEmpty)
+        XCTAssertTrue(series.uniqueStationsPerBucket.isEmpty)
+    }
+
+    func testUniqueStationsPerBucketExcludesUnknowns() {
+        let bucketOne = makeDate(year: 2026, month: 2, day: 18, hour: 8, minute: 10, second: 0)
+        let bucketTwo = makeDate(year: 2026, month: 2, day: 18, hour: 9, minute: 10, second: 0)
+        let bucketOneStart = makeDate(year: 2026, month: 2, day: 18, hour: 8, minute: 0, second: 0)
+        let bucketTwoStart = makeDate(year: 2026, month: 2, day: 18, hour: 9, minute: 0, second: 0)
+
+        let packets = [
+            makePacket(timestamp: bucketOne, from: "alpha", to: "beta"),
+            makePacket(timestamp: bucketOne, from: "alpha", to: nil),
+            makePacket(timestamp: bucketOne, from: nil, to: "gamma"),
+            makePacket(timestamp: bucketOne, from: nil, to: nil),
+            makePacket(timestamp: bucketTwo, from: "delta", to: "delta")
+        ]
+
+        let series = AnalyticsEngine.computeSeries(
+            packets: packets,
+            bucket: .hour,
+            calendar: calendar
+        )
+
+        XCTAssertEqual(series.uniqueStationsPerBucket.count, 2)
+        XCTAssertEqual(series.uniqueStationsPerBucket[0].bucket, bucketOneStart)
+        XCTAssertEqual(series.uniqueStationsPerBucket[0].value, 3)
+        XCTAssertEqual(series.uniqueStationsPerBucket[1].bucket, bucketTwoStart)
+        XCTAssertEqual(series.uniqueStationsPerBucket[1].value, 1)
+    }
+}
+
+private extension AnalyticsSeriesTests {
+    func makeDate(year: Int, month: Int, day: Int, hour: Int, minute: Int, second: Int) -> Date {
+        calendar.date(from: DateComponents(
+            calendar: calendar,
+            timeZone: calendar.timeZone,
+            year: year,
+            month: month,
+            day: day,
+            hour: hour,
+            minute: minute,
+            second: second
+        )) ?? Date(timeIntervalSince1970: 0)
+    }
+
+    func makePacket(
+        timestamp: Date,
+        from: String? = nil,
+        to: String? = nil,
+        infoBytes: [UInt8] = []
+    ) -> Packet {
+        Packet(
+            timestamp: timestamp,
+            from: from.map { AX25Address(call: $0) },
+            to: to.map { AX25Address(call: $0) },
+            via: [],
+            frameType: .ui,
+            info: Data(infoBytes)
+        )
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide chart-ready time series for packets/bytes/unique stations with adjustable time bucketing for UI charts. 
- Make bucketing deterministic and timezone-aware by injecting a `Calendar`/`TimeZone` so results are stable across environments. 
- Surface telemetry when buckets change and detect invariant violations to aid observability and Sentry reporting.

### Description
- Added `TimeBucket` and `BucketKey` (`AXTerm/Analytics/TimeBucket.swift`) with normalization logic for `minute`, `fiveMinutes`, `fifteenMinutes`, `hour`, and `day` and a `Comparable` `BucketKey` for stable ordering. 
- Added `AnalyticsSeries` and `AnalyticsSeriesPoint` (`AXTerm/Analytics/AnalyticsSeries.swift`) as simple models for chart points. 
- Implemented `AnalyticsEngine.computeSeries(packets:bucket:calendar:)` to produce deterministic `packetsPerBucket`, `bytesPerBucket`, and `uniqueStationsPerBucket` aggregations and a `points(from:)` helper for stable sorting and tie-breaking (`AXTerm/Analytics/AnalyticsEngine.swift`). 
- Extended `AnalyticsViewModel` to track `series` and `activeBucket`, added `setBucket(_:,packets:)`, wired telemetry breadcrumbs (`analytics.bucket.changed`) and measuring (`analytics.computeSeries`), and validate/capture series invariant violations (`analytics.series.invalid`) (`AXTerm/PacketEngine.swift`).

### Testing
- Added unit tests in `AXTermTests/AnalyticsSeriesTests.swift` covering five-minute boundary alignment, sorted/unique buckets, empty input, and unique-station counting excluding unknowns. 
- Tests were added to the repository but not executed in this change; please run the test suite (`swift test` / Xcode test target) to validate on CI/local environments. 
- No other automated test runs were performed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b6d1812408330b83d895898382b8d)