### PR TITLE
Add analytics graph edge computation, telemetry updates, and tests

### DIFF
--- a/AXTerm/Analytics/AnalyticsEngine+Edges.swift
+++ b/AXTerm/Analytics/AnalyticsEngine+Edges.swift
@@ -1,0 +1,65 @@
+//
+//  AnalyticsEngine+Edges.swift
+//  AXTerm
+//
+//  Created by AXTerm on 2026-02-20.
+//
+
+import Foundation
+
+extension AnalyticsEngine {
+    static func computeEdges(
+        packets: [Packet],
+        includeViaDigipeaters: Bool,
+        minCount: Int
+    ) -> [GraphEdge] {
+        guard !packets.isEmpty else { return [] }
+        let events = normalizePackets(packets)
+        var edges: [EdgeKey: EdgeAggregate] = [:]
+
+        events.forEach { event in
+            guard let from = event.from, let to = event.to else { return }
+            let path: [String]
+            if includeViaDigipeaters {
+                path = [from] + event.via + [to]
+            } else {
+                path = [from, to]
+            }
+            guard path.count >= 2 else { return }
+
+            for index in 0..<(path.count - 1) {
+                let source = path[index]
+                let target = path[index + 1]
+                guard !source.isEmpty, !target.isEmpty else { continue }
+                let key = EdgeKey(source: source, target: target)
+                var aggregate = edges[key, default: EdgeAggregate()]
+                aggregate.count += 1
+                aggregate.bytes += event.payloadBytes
+                edges[key] = aggregate
+            }
+        }
+
+        return edges
+            .map { GraphEdge(source: $0.key.source, target: $0.key.target, count: $0.value.count, bytes: $0.value.bytes) }
+            .filter { $0.count >= minCount }
+            .sorted { lhs, rhs in
+                if lhs.count == rhs.count {
+                    if lhs.source == rhs.source {
+                        return lhs.target < rhs.target
+                    }
+                    return lhs.source < rhs.source
+                }
+                return lhs.count > rhs.count
+            }
+    }
+}
+
+private struct EdgeKey: Hashable {
+    let source: String
+    let target: String
+}
+
+private struct EdgeAggregate {
+    var count: Int = 0
+    var bytes: Int = 0
+}

--- a/AXTerm/Analytics/GraphEdge.swift
+++ b/AXTerm/Analytics/GraphEdge.swift
@@ -1,0 +1,15 @@
+//
+//  GraphEdge.swift
+//  AXTerm
+//
+//  Created by AXTerm on 2026-02-20.
+//
+
+import Foundation
+
+struct GraphEdge: Hashable, Sendable {
+    let source: String
+    let target: String
+    let count: Int
+    let bytes: Int?
+}

--- a/AXTerm/Observability/TelemetryBackend.swift
+++ b/AXTerm/Observability/TelemetryBackend.swift
@@ -27,6 +27,7 @@ protocol TelemetryBackend {
 
     func addBreadcrumb(category: String, message: String, data: [String: Any]?, level: TelemetryLevel)
     func startSpan(name: String, operation: String?, data: [String: Any]?) -> TelemetrySpanToken?
+    func updateSpan(_ span: TelemetrySpanToken?, data: [String: Any])
     func finishSpan(_ span: TelemetrySpanToken?, status: TelemetrySpanStatus)
     func capture(error: Error, message: String, data: [String: Any]?)
     func capture(message: String, data: [String: Any]?)
@@ -37,6 +38,7 @@ struct NoOpTelemetryBackend: TelemetryBackend {
 
     func addBreadcrumb(category: String, message: String, data: [String: Any]?, level: TelemetryLevel) {}
     func startSpan(name: String, operation: String?, data: [String: Any]?) -> TelemetrySpanToken? { nil }
+    func updateSpan(_ span: TelemetrySpanToken?, data: [String: Any]) {}
     func finishSpan(_ span: TelemetrySpanToken?, status: TelemetrySpanStatus) {}
     func capture(error: Error, message: String, data: [String: Any]?) {}
     func capture(message: String, data: [String: Any]?) {}
@@ -79,6 +81,14 @@ final class SentryTelemetryBackend: TelemetryBackend {
             }
         }
         return span
+    }
+
+    func updateSpan(_ span: TelemetrySpanToken?, data: [String: Any]) {
+        guard SentrySDK.isEnabled else { return }
+        guard let span = span as? Span else { return }
+        for (key, value) in data {
+            span.setData(value: value, key: key)
+        }
     }
 
     func finishSpan(_ span: TelemetrySpanToken?, status _: TelemetrySpanStatus) {

--- a/AXTermTests/AnalyticsEdgesTests.swift
+++ b/AXTermTests/AnalyticsEdgesTests.swift
@@ -1,0 +1,157 @@
+//
+//  AnalyticsEdgesTests.swift
+//  AXTermTests
+//
+//  Created by AXTerm on 2026-02-20.
+//
+
+import XCTest
+@testable import AXTerm
+
+final class AnalyticsEdgesTests: XCTestCase {
+    func testComputeEdgesWithoutDigipeaters() {
+        let packet = Packet(
+            timestamp: Date(),
+            from: AX25Address(call: "src"),
+            to: AX25Address(call: "dst"),
+            via: [AX25Address(call: "dig1"), AX25Address(call: "dig2")],
+            frameType: .ui,
+            info: Data([0x01, 0x02])
+        )
+
+        let edges = AnalyticsEngine.computeEdges(
+            packets: [packet],
+            includeViaDigipeaters: false,
+            minCount: 1
+        )
+
+        XCTAssertEqual(edges, [GraphEdge(source: "SRC", target: "DST", count: 1, bytes: 2)])
+    }
+
+    func testComputeEdgesWithDigipeaters() {
+        let packet = Packet(
+            timestamp: Date(),
+            from: AX25Address(call: "src"),
+            to: AX25Address(call: "dst"),
+            via: [AX25Address(call: "dig1"), AX25Address(call: "dig2")],
+            frameType: .ui,
+            info: Data([0x01, 0x02])
+        )
+
+        let edges = AnalyticsEngine.computeEdges(
+            packets: [packet],
+            includeViaDigipeaters: true,
+            minCount: 1
+        )
+
+        let expected: Set<GraphEdge> = [
+            GraphEdge(source: "SRC", target: "DIG1", count: 1, bytes: 2),
+            GraphEdge(source: "DIG1", target: "DIG2", count: 1, bytes: 2),
+            GraphEdge(source: "DIG2", target: "DST", count: 1, bytes: 2)
+        ]
+
+        XCTAssertEqual(Set(edges), expected)
+    }
+
+    func testComputeEdgesMinCountFilters() {
+        let packet1 = Packet(
+            timestamp: Date(),
+            from: AX25Address(call: "a"),
+            to: AX25Address(call: "b"),
+            frameType: .ui,
+            info: Data([0x01])
+        )
+        let packet2 = Packet(
+            timestamp: Date(),
+            from: AX25Address(call: "a"),
+            to: AX25Address(call: "b"),
+            frameType: .ui,
+            info: Data([0x02, 0x03])
+        )
+        let packet3 = Packet(
+            timestamp: Date(),
+            from: AX25Address(call: "c"),
+            to: AX25Address(call: "d"),
+            frameType: .ui,
+            info: Data([0x04])
+        )
+
+        let edges = AnalyticsEngine.computeEdges(
+            packets: [packet1, packet2, packet3],
+            includeViaDigipeaters: false,
+            minCount: 2
+        )
+
+        XCTAssertEqual(edges, [GraphEdge(source: "A", target: "B", count: 2, bytes: 3)])
+    }
+
+    func testComputeEdgesSkipsUnknownFromOrTo() {
+        let packet1 = Packet(
+            timestamp: Date(),
+            from: nil,
+            to: AX25Address(call: "dest"),
+            frameType: .ui,
+            info: Data([0x01])
+        )
+        let packet2 = Packet(
+            timestamp: Date(),
+            from: AX25Address(call: "src"),
+            to: nil,
+            frameType: .ui,
+            info: Data([0x02])
+        )
+        let packet3 = Packet(
+            timestamp: Date(),
+            from: AX25Address(call: "src"),
+            to: AX25Address(call: "dest"),
+            frameType: .ui,
+            info: Data([0x03])
+        )
+
+        let edges = AnalyticsEngine.computeEdges(
+            packets: [packet1, packet2, packet3],
+            includeViaDigipeaters: false,
+            minCount: 1
+        )
+
+        XCTAssertEqual(edges, [GraphEdge(source: "SRC", target: "DEST", count: 1, bytes: 1)])
+    }
+
+    func testComputeEdgesDeterministicOrderingWithTies() {
+        let packet1 = Packet(
+            timestamp: Date(),
+            from: AX25Address(call: "a"),
+            to: AX25Address(call: "c"),
+            frameType: .ui,
+            info: Data([0x01])
+        )
+        let packet2 = Packet(
+            timestamp: Date(),
+            from: AX25Address(call: "a"),
+            to: AX25Address(call: "b"),
+            frameType: .ui,
+            info: Data([0x02])
+        )
+        let packet3 = Packet(
+            timestamp: Date(),
+            from: AX25Address(call: "b"),
+            to: AX25Address(call: "a"),
+            frameType: .ui,
+            info: Data([0x03])
+        )
+
+        let edges = AnalyticsEngine.computeEdges(
+            packets: [packet1, packet2, packet3],
+            includeViaDigipeaters: false,
+            minCount: 1
+        )
+
+        let expected = [
+            GraphEdge(source: "A", target: "B", count: 1, bytes: 1),
+            GraphEdge(source: "A", target: "C", count: 1, bytes: 1),
+            GraphEdge(source: "B", target: "A", count: 1, bytes: 1)
+        ]
+
+        XCTAssertEqual(edges, expected)
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a station-to-station communication graph (edge list) for network graph views and analytics UI driven by packet data.
- Expose graph controls (include-via digipeaters and min count) in the analytics orchestration and report metrics to telemetry/Sentry.

### Description

- Add `GraphEdge` model (`AXTerm/Analytics/GraphEdge.swift`) and implement `AnalyticsEngine.computeEdges(packets:includeViaDigipeaters:minCount:)` in `AXTerm/Analytics/AnalyticsEngine+Edges.swift` which normalizes packets, optionally expands digipeater paths, skips unknown endpoints, collapses duplicates by summing `count` and `bytes`, and returns a deterministic sort (count desc, source asc, target asc).
- Update telemetry to support updating span data after computation by adding `Telemetry.measureWithResult` and `TelemetryBackend.updateSpan` hooks in `AXTerm/Observability/Telemetry.swift` and `AXTerm/Observability/TelemetryBackend.swift` so edge counts are recorded on the span.
- Extend analytics orchestration in `AnalyticsViewModel` (`AXTerm/PacketEngine.swift`) to expose `graphEdges`, `includeViaDigipeaters`, and `graphMinCount`, add `setGraphIncludeViaDigipeaters`/`setGraphMinCount` helpers, compute edges via `AnalyticsEngine.computeEdges`, breadcrumb changes with category `analytics.graph.includeVia.changed`, measure the `analytics.computeEdges` span with `packetCount`, `includeVia`, and `minCount`, and capture an `analytics.edges.invalid` message if any edge has empty source/target or non-positive count.
- Add unit tests covering digipeater inclusion, minCount filtering, unknown handling, and deterministic ordering in `AXTermTests/AnalyticsEdgesTests.swift`.

### Testing

- Added unit tests in `AXTermTests/AnalyticsEdgesTests.swift` covering the expected edge sets for `includeViaDigipeaters` true/false, `minCount` filtering, skipping unknown endpoints, and deterministic ordering with ties (tests not executed here).
- No automated test run was performed as part of this change set in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b724aa3e8833096260fe25af9c9a4)