### PR TITLE
Add deterministic radial graph layout engine and integrate with analytics

### DIFF
--- a/AXTerm/Analytics/GraphLayoutEngine.swift
+++ b/AXTerm/Analytics/GraphLayoutEngine.swift
@@ -1,0 +1,109 @@
+//
+//  GraphLayoutEngine.swift
+//  AXTerm
+//
+//  Created by AXTerm on 2026-02-20.
+//
+
+import CoreGraphics
+import Foundation
+
+struct GraphLayoutResult: Hashable, Sendable {
+    let nodes: [NodePosition]
+    let edges: [GraphEdge]
+
+    static let empty = GraphLayoutResult(nodes: [], edges: [])
+}
+
+enum GraphLayoutEngine {
+    static let algorithmName = "radial"
+    static let iterations = 1
+
+    static func layout(
+        nodes: [GraphNode],
+        edges: [GraphEdge],
+        size: CGSize,
+        seed: Int
+    ) -> [NodePosition] {
+        _ = edges
+        guard !nodes.isEmpty else { return [] }
+
+        let orderedNodes = nodes.sorted { lhs, rhs in
+            if lhs.degree != rhs.degree {
+                return lhs.degree > rhs.degree
+            }
+            if lhs.count != rhs.count {
+                return lhs.count > rhs.count
+            }
+            let lhsBytes = lhs.bytes ?? 0
+            let rhsBytes = rhs.bytes ?? 0
+            if lhsBytes != rhsBytes {
+                return lhsBytes > rhsBytes
+            }
+            return lhs.id < rhs.id
+        }
+
+        let safeWidth = size.width.isFinite ? Double(max(0, size.width)) : 0
+        let safeHeight = size.height.isFinite ? Double(max(0, size.height)) : 0
+        let padding = min(24.0, min(safeWidth, safeHeight) * 0.1)
+        let paddingX = min(padding, safeWidth / 2)
+        let paddingY = min(padding, safeHeight / 2)
+        let centerX = safeWidth / 2
+        let centerY = safeHeight / 2
+        let availableWidth = max(0, safeWidth - paddingX * 2)
+        let availableHeight = max(0, safeHeight - paddingY * 2)
+        let radius = max(0, min(availableWidth, availableHeight) / 2)
+
+        var generator = SeededGenerator(seed: seed)
+        let startAngle: Double
+        if orderedNodes.count > 1 {
+            startAngle = Double.random(in: 0 ..< (Double.pi * 2), using: &generator)
+        } else {
+            startAngle = 0
+        }
+        let step = orderedNodes.count > 1 ? (Double.pi * 2) / Double(orderedNodes.count - 1) : 0
+
+        var positions: [NodePosition] = []
+        positions.reserveCapacity(orderedNodes.count)
+
+        for (index, node) in orderedNodes.enumerated() {
+            let x: Double
+            let y: Double
+            if index == 0 {
+                x = centerX
+                y = centerY
+            } else {
+                let angle = startAngle + step * Double(index - 1)
+                x = centerX + radius * cos(angle)
+                y = centerY + radius * sin(angle)
+            }
+
+            let clampedX = clamp(x, min: paddingX, max: safeWidth - paddingX)
+            let clampedY = clamp(y, min: paddingY, max: safeHeight - paddingY)
+            positions.append(NodePosition(id: node.id, x: clampedX, y: clampedY))
+        }
+
+        return positions
+    }
+
+    private static func clamp(_ value: Double, min: Double, max: Double) -> Double {
+        if min > max {
+            return max
+        }
+        return Swift.max(min, Swift.min(max, value))
+    }
+}
+
+private struct SeededGenerator: RandomNumberGenerator {
+    private var state: UInt64
+
+    init(seed: Int) {
+        let seedValue = UInt64(bitPattern: Int64(seed))
+        state = seedValue == 0 ? 0x9E3779B97F4A7C15 : seedValue
+    }
+
+    mutating func next() -> UInt64 {
+        state = 6364136223846793005 &* state &+ 1442695040888963407
+        return state
+    }
+}

--- a/AXTerm/Analytics/GraphNode.swift
+++ b/AXTerm/Analytics/GraphNode.swift
@@ -1,0 +1,15 @@
+//
+//  GraphNode.swift
+//  AXTerm
+//
+//  Created by AXTerm on 2026-02-20.
+//
+
+import Foundation
+
+struct GraphNode: Hashable, Sendable {
+    let id: String
+    let degree: Int
+    let count: Int
+    let bytes: Int?
+}

--- a/AXTerm/Analytics/NodePosition.swift
+++ b/AXTerm/Analytics/NodePosition.swift
@@ -1,0 +1,14 @@
+//
+//  NodePosition.swift
+//  AXTerm
+//
+//  Created by AXTerm on 2026-02-20.
+//
+
+import Foundation
+
+struct NodePosition: Hashable, Sendable {
+    let id: String
+    let x: Double
+    let y: Double
+}

--- a/AXTermTests/GraphLayoutEngineTests.swift
+++ b/AXTermTests/GraphLayoutEngineTests.swift
@@ -1,0 +1,73 @@
+//
+//  GraphLayoutEngineTests.swift
+//  AXTermTests
+//
+//  Created by AXTerm on 2026-02-20.
+//
+
+import CoreGraphics
+import XCTest
+@testable import AXTerm
+
+final class GraphLayoutEngineTests: XCTestCase {
+    func testLayoutIsDeterministicWithSeed() {
+        let nodes = [
+            GraphNode(id: "A", degree: 2, count: 10, bytes: 50),
+            GraphNode(id: "B", degree: 1, count: 5, bytes: 20),
+            GraphNode(id: "C", degree: 1, count: 2, bytes: 10)
+        ]
+        let edges = [
+            GraphEdge(source: "A", target: "B", count: 5, bytes: 20),
+            GraphEdge(source: "A", target: "C", count: 2, bytes: 10)
+        ]
+        let size = CGSize(width: 200, height: 160)
+
+        let first = GraphLayoutEngine.layout(nodes: nodes, edges: edges, size: size, seed: 42)
+        let second = GraphLayoutEngine.layout(nodes: nodes, edges: edges, size: size, seed: 42)
+
+        XCTAssertEqual(first, second)
+    }
+
+    func testLayoutPositionsAreFinite() {
+        let nodes = [
+            GraphNode(id: "A", degree: 2, count: 10, bytes: 50),
+            GraphNode(id: "B", degree: 1, count: 5, bytes: 20)
+        ]
+        let edges = [
+            GraphEdge(source: "A", target: "B", count: 5, bytes: 20)
+        ]
+        let size = CGSize(width: 120, height: 120)
+
+        let positions = GraphLayoutEngine.layout(nodes: nodes, edges: edges, size: size, seed: 7)
+
+        XCTAssertTrue(positions.allSatisfy { $0.x.isFinite && $0.y.isFinite })
+    }
+
+    func testLayoutPositionsAreWithinBounds() {
+        let nodes = [
+            GraphNode(id: "A", degree: 3, count: 10, bytes: 50),
+            GraphNode(id: "B", degree: 2, count: 7, bytes: 20),
+            GraphNode(id: "C", degree: 1, count: 3, bytes: 12)
+        ]
+        let edges = [
+            GraphEdge(source: "A", target: "B", count: 3, bytes: 12),
+            GraphEdge(source: "A", target: "C", count: 1, bytes: 5)
+        ]
+        let size = CGSize(width: 180, height: 140)
+
+        let positions = GraphLayoutEngine.layout(nodes: nodes, edges: edges, size: size, seed: 11)
+
+        for position in positions {
+            XCTAssertGreaterThanOrEqual(position.x, 0)
+            XCTAssertLessThanOrEqual(position.x, Double(size.width))
+            XCTAssertGreaterThanOrEqual(position.y, 0)
+            XCTAssertLessThanOrEqual(position.y, Double(size.height))
+        }
+    }
+
+    func testLayoutHandlesEmptyNodes() {
+        let positions = GraphLayoutEngine.layout(nodes: [], edges: [], size: .zero, seed: 0)
+
+        XCTAssertTrue(positions.isEmpty)
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a deterministic, pure compute layout for the upcoming Network Graph feature so positions can be calculated server-side / headlessly without UI code.
- Ensure layouts are repeatable by seed and stable node ordering and to surface telemetry when layout invariants fail.

### Description
- Add lightweight graph models and layout engine: `GraphNode.swift`, `NodePosition.swift`, and `GraphLayoutEngine.swift` implementing a seeded radial layout and clamped positions with a small padding and deterministic ordering (`degree`, `count`, `bytes`, then `id`).
- Add `GraphLayoutResult` and expose a seeded `GraphLayoutEngine.layout(nodes:edges:size:seed:) -> [NodePosition]` entry point that returns stable positions and uses a small seeded RNG.
- Wire layout computation into the analytics view model (`AnalyticsViewModel` in `PacketEngine.swift`) by adding a `@Published var graphLayout: GraphLayoutResult`, `updateGraphLayout(...)`, automatic recompute on edge changes, building `GraphNode` metrics from `GraphEdge`, and validating layout invariants.
- Add telemetry instrumentation: breadcrumb when the layout is recomputed and a measured span `analytics.graph.layout` including `nodeCount`, `edgeCount`, `algorithm`, and `iterations`, plus capture of invalid/non-finite/out-of-bounds layout results.
- Add unit tests `AXTermTests/GraphLayoutEngineTests.swift` covering determinism (same seed -> same positions), non-NaN/Inf coordinates, bounds clamping (within width/height), and empty input handling.

### Testing
- Added `GraphLayoutEngineTests` (determinism, finiteness, bounds, empty input) to the test target but did not run the test-suite in this rollout.
- Runtime layout validation is performed at `recomputeGraphLayout` and will record telemetry if any invalid positions or invariant failures are detected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b7542c5108330b0afff098603380e)