### PR TITLE
Add analytics dashboard view model, UI, and tests

### DIFF
--- a/AXTerm/Analytics/AnalyticsDashboardView.swift
+++ b/AXTerm/Analytics/AnalyticsDashboardView.swift
@@ -11,7 +11,7 @@ struct AnalyticsDashboardView: View {
     @ObservedObject var packetEngine: PacketEngine
     @StateObject private var viewModel: AnalyticsDashboardViewModel
 
-    init(packetEngine: PacketEngine, viewModel: AnalyticsDashboardViewModel = AnalyticsDashboardViewModel()) {
+    @MainActor init(packetEngine: PacketEngine, viewModel: AnalyticsDashboardViewModel = AnalyticsDashboardViewModel()) {
         self.packetEngine = packetEngine
         _viewModel = StateObject(wrappedValue: viewModel)
     }
@@ -256,7 +256,7 @@ private struct AnalyticsGraphView: View {
             .onAppear {
                 viewModel.updateLayout(size: proxy.size)
             }
-            .onChange(of: proxy.size) { newSize in
+            .onChange(of: proxy.size) { _, newSize in
                 viewModel.updateLayout(size: newSize)
             }
         }

--- a/AXTerm/Analytics/AnalyticsDashboardView.swift
+++ b/AXTerm/Analytics/AnalyticsDashboardView.swift
@@ -11,7 +11,7 @@ struct AnalyticsDashboardView: View {
     @ObservedObject var packetEngine: PacketEngine
     @StateObject private var viewModel: AnalyticsDashboardViewModel
 
-    @MainActor init(packetEngine: PacketEngine, viewModel: AnalyticsDashboardViewModel = AnalyticsDashboardViewModel()) {
+    init(packetEngine: PacketEngine, viewModel: AnalyticsDashboardViewModel) {
         self.packetEngine = packetEngine
         _viewModel = StateObject(wrappedValue: viewModel)
     }

--- a/AXTerm/Analytics/AnalyticsDashboardView.swift
+++ b/AXTerm/Analytics/AnalyticsDashboardView.swift
@@ -1,0 +1,279 @@
+//
+//  AnalyticsDashboardView.swift
+//  AXTerm
+//
+//  Created by AXTerm on 2026-02-21.
+//
+
+import SwiftUI
+
+struct AnalyticsDashboardView: View {
+    @ObservedObject var packetEngine: PacketEngine
+    @StateObject private var viewModel: AnalyticsDashboardViewModel
+
+    init(packetEngine: PacketEngine, viewModel: AnalyticsDashboardViewModel = AnalyticsDashboardViewModel()) {
+        self.packetEngine = packetEngine
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                filterSection
+                summarySection
+                chartsSection
+                graphSection
+            }
+            .padding()
+        }
+        .onAppear {
+            viewModel.trackDashboardOpened()
+            viewModel.updatePackets(packetEngine.packets)
+        }
+        .onReceive(packetEngine.$packets) { packets in
+            viewModel.updatePackets(packets)
+        }
+    }
+
+    private var filterSection: some View {
+        GroupBox("Filters") {
+            VStack(alignment: .leading, spacing: 12) {
+                Picker("Bucket", selection: $viewModel.bucket) {
+                    ForEach(TimeBucket.allCases, id: \.self) { bucket in
+                        Text(bucket.displayName).tag(bucket)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                Toggle("Include via digipeaters", isOn: $viewModel.includeViaDigipeaters)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Minimum edge count: \(viewModel.minEdgeCount)")
+                    Slider(
+                        value: Binding(
+                            get: { Double(viewModel.minEdgeCount) },
+                            set: { viewModel.minEdgeCount = Int($0) }
+                        ),
+                        in: 1...10,
+                        step: 1
+                    )
+                }
+            }
+            .padding(.vertical, 4)
+        }
+    }
+
+    private var summarySection: some View {
+        GroupBox("Summary") {
+            if let summary = viewModel.summary {
+                VStack(alignment: .leading, spacing: 12) {
+                    HStack(spacing: 16) {
+                        SummaryCard(title: "Packets", value: "\(summary.packetCount)")
+                        SummaryCard(title: "Unique stations", value: "\(summary.uniqueStationsCount)")
+                        SummaryCard(title: "Payload bytes", value: "\(summary.totalPayloadBytes)")
+                    }
+
+                    HStack(spacing: 16) {
+                        SummaryCard(title: "Info text ratio", value: String(format: "%.0f%%", summary.infoTextRatio * 100))
+                        SummaryCard(title: "UI frames", value: "\(summary.frameTypeCounts[.ui, default: 0])")
+                        SummaryCard(title: "I frames", value: "\(summary.frameTypeCounts[.i, default: 0])")
+                    }
+
+                    HStack(alignment: .top, spacing: 24) {
+                        StationList(title: "Top talkers", stations: summary.topTalkersByFrom)
+                        StationList(title: "Top destinations", stations: summary.topDestinationsByTo)
+                    }
+                }
+                .padding(.vertical, 4)
+            } else {
+                Text("No packets yet")
+                    .foregroundStyle(.secondary)
+                    .padding(.vertical, 8)
+            }
+        }
+    }
+
+    private var chartsSection: some View {
+        GroupBox("Charts") {
+            VStack(alignment: .leading, spacing: 12) {
+                AnalyticsSeriesPreview(title: "Packets", points: viewModel.series.packetsPerBucket)
+                AnalyticsSeriesPreview(title: "Bytes", points: viewModel.series.bytesPerBucket)
+                AnalyticsSeriesPreview(title: "Unique stations", points: viewModel.series.uniqueStationsPerBucket)
+            }
+            .padding(.vertical, 4)
+        }
+    }
+
+    private var graphSection: some View {
+        GroupBox("Network graph") {
+            VStack(alignment: .leading, spacing: 8) {
+                AnalyticsGraphView(viewModel: viewModel)
+                    .frame(minHeight: 260)
+
+                HStack {
+                    Text("Selected: \(viewModel.selectedNodeID ?? "None")")
+                    Spacer()
+                    Text("Pinned: \(viewModel.pinnedNodeID ?? "None")")
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+                Text("Tip: click to select, double-click to pin.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.vertical, 4)
+        }
+    }
+}
+
+private struct SummaryCard: View {
+    let title: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.headline)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(Color.secondary.opacity(0.1))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+private struct StationList: View {
+    let title: String
+    let stations: [StationCount]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            if stations.isEmpty {
+                Text("No data")
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(Array(stations.enumerated()), id: \.offset) { _, station in
+                    HStack {
+                        Text(station.station)
+                        Spacer()
+                        Text("\(station.count)")
+                            .foregroundStyle(.secondary)
+                    }
+                    .font(.caption)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct AnalyticsSeriesPreview: View {
+    let title: String
+    let points: [AnalyticsSeriesPoint]
+
+    private static let formatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        return formatter
+    }()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.headline)
+            if points.isEmpty {
+                Text("No data")
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            } else {
+                ForEach(Array(points.prefix(8).enumerated()), id: \.offset) { _, point in
+                    HStack {
+                        Text(Self.formatter.string(from: point.bucket))
+                            .frame(width: 60, alignment: .leading)
+                        Spacer()
+                        Text("\(point.value)")
+                    }
+                    .font(.caption)
+                }
+            }
+        }
+        .padding(10)
+        .background(Color.secondary.opacity(0.08))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+private struct AnalyticsGraphView: View {
+    @ObservedObject var viewModel: AnalyticsDashboardViewModel
+
+    var body: some View {
+        GeometryReader { proxy in
+            ZStack {
+                Canvas { context, _ in
+                    let positions = Dictionary(uniqueKeysWithValues: viewModel.nodePositions.map {
+                        ($0.id, CGPoint(x: $0.x, y: $0.y))
+                    })
+                    for edge in viewModel.edges {
+                        guard let source = positions[edge.source], let target = positions[edge.target] else { continue }
+                        var path = Path()
+                        path.move(to: source)
+                        path.addLine(to: target)
+                        context.stroke(path, with: .color(.secondary.opacity(0.4)), lineWidth: 1)
+                    }
+                }
+
+                ForEach(viewModel.nodePositions, id: \.id) { node in
+                    let isSelected = viewModel.selectedNodeID == node.id
+                    let isPinned = viewModel.pinnedNodeID == node.id
+                    let isHovered = viewModel.hoveredNodeID == node.id
+
+                    Circle()
+                        .fill(nodeColor(selected: isSelected, pinned: isPinned, hovered: isHovered))
+                        .frame(width: isPinned ? 16 : 12, height: isPinned ? 16 : 12)
+                        .overlay(
+                            Circle()
+                                .stroke(isSelected ? Color.accentColor : .clear, lineWidth: 2)
+                        )
+                        .position(x: node.x, y: node.y)
+                        .onTapGesture {
+                            viewModel.selectNode(node.id)
+                        }
+                        .onTapGesture(count: 2) {
+                            viewModel.togglePinnedNode(node.id)
+                        }
+                        .onHover { hovering in
+                            viewModel.updateHover(for: node.id, isHovering: hovering)
+                        }
+                }
+            }
+            .onAppear {
+                viewModel.updateLayout(size: proxy.size)
+            }
+            .onChange(of: proxy.size) { newSize in
+                viewModel.updateLayout(size: newSize)
+            }
+        }
+        .background(Color.secondary.opacity(0.06))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    private func nodeColor(selected: Bool, pinned: Bool, hovered: Bool) -> Color {
+        if pinned {
+            return .orange
+        }
+        if selected {
+            return .accentColor
+        }
+        if hovered {
+            return .blue
+        }
+        return .primary
+    }
+}

--- a/AXTerm/Analytics/AnalyticsDashboardViewModel.swift
+++ b/AXTerm/Analytics/AnalyticsDashboardViewModel.swift
@@ -1,0 +1,361 @@
+//
+//  AnalyticsDashboardViewModel.swift
+//  AXTerm
+//
+//  Created by AXTerm on 2026-02-21.
+//
+
+import Combine
+import CoreGraphics
+import Foundation
+
+@MainActor
+final class AnalyticsDashboardViewModel: ObservableObject {
+    @Published var bucket: TimeBucket {
+        didSet {
+            guard bucket != oldValue else { return }
+            trackFilterChange(reason: "bucket")
+            recomputeSeries(packets: packets)
+        }
+    }
+    @Published var includeViaDigipeaters: Bool {
+        didSet {
+            guard includeViaDigipeaters != oldValue else { return }
+            trackFilterChange(reason: "includeVia")
+            recomputeAll(packets: packets)
+        }
+    }
+    @Published var minEdgeCount: Int {
+        didSet {
+            guard minEdgeCount != oldValue else { return }
+            trackFilterChange(reason: "minEdgeCount")
+            recomputeEdges(packets: packets)
+        }
+    }
+
+    @Published private(set) var summary: AnalyticsSummary?
+    @Published private(set) var series: AnalyticsSeries = .empty
+    @Published private(set) var edges: [GraphEdge] = []
+    @Published private(set) var nodePositions: [NodePosition] = []
+
+    @Published var selectedNodeID: String?
+    @Published var hoveredNodeID: String?
+    @Published var pinnedNodeID: String?
+
+    private let calendar: Calendar
+    private let packetSubject = CurrentValueSubject<[Packet], Never>([])
+    private var cancellables: Set<AnyCancellable> = []
+    private var packets: [Packet] = []
+    private var graphLayoutSize: CGSize = .zero
+    private var graphLayoutSeed: Int = 1
+    private let packetDebounce: RunLoop.SchedulerTimeType.Stride
+    private let packetScheduler: RunLoop
+
+    init(
+        calendar: Calendar = .current,
+        bucket: TimeBucket = .fiveMinutes,
+        includeViaDigipeaters: Bool = false,
+        minEdgeCount: Int = 1,
+        packetDebounce: RunLoop.SchedulerTimeType.Stride = .milliseconds(150),
+        packetScheduler: RunLoop = .main
+    ) {
+        self.calendar = calendar
+        self.bucket = bucket
+        self.includeViaDigipeaters = includeViaDigipeaters
+        self.minEdgeCount = minEdgeCount
+        self.packetDebounce = packetDebounce
+        self.packetScheduler = packetScheduler
+        bindPackets()
+    }
+
+    func updatePackets(_ packets: [Packet]) {
+        packetSubject.send(packets)
+    }
+
+    func updateLayout(size: CGSize, seed: Int = 1) {
+        graphLayoutSize = size
+        graphLayoutSeed = seed
+        recomputeLayout(reason: "layoutRequested")
+    }
+
+    func trackDashboardOpened() {
+        Telemetry.breadcrumb(
+            category: "analytics.dashboard.opened",
+            message: "Analytics dashboard opened",
+            data: nil
+        )
+    }
+
+    func selectNode(_ nodeID: String?) {
+        selectedNodeID = nodeID
+        guard let nodeID else { return }
+        Telemetry.breadcrumb(
+            category: "analytics.graph.node.selected",
+            message: "Analytics graph node selected",
+            data: ["nodeID": nodeID]
+        )
+    }
+
+    func togglePinnedNode(_ nodeID: String) {
+        pinnedNodeID = pinnedNodeID == nodeID ? nil : nodeID
+    }
+
+    func updateHover(for nodeID: String, isHovering: Bool) {
+        if isHovering {
+            hoveredNodeID = nodeID
+        } else if hoveredNodeID == nodeID {
+            hoveredNodeID = nil
+        }
+    }
+
+    private func bindPackets() {
+        let pipeline = packetSubject
+            .removeDuplicates(by: { lhs, rhs in
+                lhs.count == rhs.count && lhs.last?.id == rhs.last?.id
+            })
+
+        if packetDebounce == .zero {
+            pipeline
+                .sink { [weak self] packets in
+                    self?.packets = packets
+                    self?.recomputeAll(packets: packets)
+                }
+                .store(in: &cancellables)
+        } else {
+            pipeline
+                .debounce(for: packetDebounce, scheduler: packetScheduler)
+                .sink { [weak self] packets in
+                    self?.packets = packets
+                    self?.recomputeAll(packets: packets)
+                }
+                .store(in: &cancellables)
+        }
+    }
+
+    private func trackFilterChange(reason: String) {
+        Telemetry.breadcrumb(
+            category: "analytics.filter.changed",
+            message: "Analytics filter changed",
+            data: [
+                "reason": reason,
+                "bucket": bucket.displayName,
+                "includeVia": includeViaDigipeaters,
+                "minEdgeCount": minEdgeCount
+            ]
+        )
+    }
+
+    private func recomputeAll(packets: [Packet]) {
+        recomputeSummary(packets: packets)
+        recomputeSeries(packets: packets)
+        recomputeEdges(packets: packets)
+    }
+
+    private func recomputeSummary(packets: [Packet]) {
+        let uniqueStations = AnalyticsEngine.uniqueStationsCount(
+            packets: packets,
+            includeViaInUniqueStations: includeViaDigipeaters
+        )
+
+        let summary = Telemetry.measure(
+            name: "analytics.computeSummary",
+            data: [
+                TelemetryContext.packetCount: packets.count,
+                TelemetryContext.uniqueStations: uniqueStations
+            ]
+        ) {
+            AnalyticsEngine.computeSummary(
+                packets: packets,
+                includeViaInUniqueStations: includeViaDigipeaters
+            )
+        }
+        self.summary = summary
+
+        if summary.infoTextRatio.isNaN || summary.totalPayloadBytes < 0 {
+            Telemetry.capture(
+                message: "analytics.summary.invalid",
+                data: [
+                    "infoTextRatio": summary.infoTextRatio,
+                    "totalPayloadBytes": summary.totalPayloadBytes
+                ]
+            )
+        }
+    }
+
+    private func recomputeSeries(packets: [Packet]) {
+        let uniqueStations = AnalyticsEngine.uniqueStationsCount(
+            packets: packets,
+            includeViaInUniqueStations: includeViaDigipeaters
+        )
+
+        let series = Telemetry.measure(
+            name: "analytics.computeSeries",
+            data: [
+                TelemetryContext.packetCount: packets.count,
+                TelemetryContext.uniqueStations: uniqueStations,
+                TelemetryContext.activeBucket: bucket.displayName
+            ]
+        ) {
+            AnalyticsEngine.computeSeries(
+                packets: packets,
+                bucket: bucket,
+                calendar: calendar,
+                includeViaInUniqueStations: includeViaDigipeaters
+            )
+        }
+        self.series = series
+
+        let seriesIssues = validateSeries(series)
+        if !seriesIssues.isEmpty {
+            Telemetry.capture(
+                message: "analytics.series.invalid",
+                data: [
+                    "issues": seriesIssues,
+                    "bucket": bucket.displayName
+                ]
+            )
+        }
+    }
+
+    private func recomputeEdges(packets: [Packet]) {
+        let uniqueStations = AnalyticsEngine.uniqueStationsCount(
+            packets: packets,
+            includeViaInUniqueStations: includeViaDigipeaters
+        )
+
+        let edges = Telemetry.measureWithResult(
+            name: "analytics.computeEdges",
+            data: [
+                TelemetryContext.packetCount: packets.count,
+                TelemetryContext.uniqueStations: uniqueStations,
+                "includeVia": includeViaDigipeaters,
+                "minCount": minEdgeCount
+            ],
+            updateData: { result in
+                ["edgeCount": result.count]
+            }
+        ) {
+            AnalyticsEngine.computeEdges(
+                packets: packets,
+                includeViaDigipeaters: includeViaDigipeaters,
+                minCount: minEdgeCount
+            )
+        }
+        self.edges = edges
+
+        if edges.contains(where: { $0.source.isEmpty || $0.target.isEmpty || $0.count <= 0 }) {
+            Telemetry.capture(
+                message: "analytics.edges.invalid",
+                data: [
+                    "includeVia": includeViaDigipeaters,
+                    "minCount": minEdgeCount,
+                    "edgeCount": edges.count
+                ]
+            )
+        }
+
+        recomputeLayout(reason: "edgesUpdated")
+    }
+
+    private func recomputeLayout(reason: String) {
+        let nodes = buildGraphNodes(from: edges)
+
+        let positions = Telemetry.measure(
+            name: "analytics.graph.layout",
+            data: [
+                "nodeCount": nodes.count,
+                "edgeCount": edges.count,
+                "algorithm": GraphLayoutEngine.algorithmName,
+                "iterations": GraphLayoutEngine.iterations,
+                "reason": reason
+            ]
+        ) {
+            GraphLayoutEngine.layout(
+                nodes: nodes,
+                edges: edges,
+                size: graphLayoutSize,
+                seed: graphLayoutSeed
+            )
+        }
+        nodePositions = positions
+
+        let invalidPositions = positions.filter { !$0.x.isFinite || !$0.y.isFinite }
+        if !invalidPositions.isEmpty {
+            Telemetry.capture(
+                message: "analytics.graph.layout.invalid",
+                data: [
+                    "nodeCount": nodes.count,
+                    "edgeCount": edges.count,
+                    "invalidCount": invalidPositions.count
+                ]
+            )
+        }
+    }
+
+    private func buildGraphNodes(from edges: [GraphEdge]) -> [GraphNode] {
+        struct NodeMetrics {
+            var degree: Int = 0
+            var count: Int = 0
+            var bytes: Int = 0
+            var hasBytes: Bool = false
+        }
+
+        var metricsById: [String: NodeMetrics] = [:]
+        for edge in edges {
+            let edgeBytes = edge.bytes
+
+            var sourceMetrics = metricsById[edge.source, default: NodeMetrics()]
+            sourceMetrics.degree += 1
+            sourceMetrics.count += edge.count
+            if let edgeBytes {
+                sourceMetrics.bytes += edgeBytes
+                sourceMetrics.hasBytes = true
+            }
+            metricsById[edge.source] = sourceMetrics
+
+            var targetMetrics = metricsById[edge.target, default: NodeMetrics()]
+            targetMetrics.degree += 1
+            targetMetrics.count += edge.count
+            if let edgeBytes {
+                targetMetrics.bytes += edgeBytes
+                targetMetrics.hasBytes = true
+            }
+            metricsById[edge.target] = targetMetrics
+        }
+
+        return metricsById.map { key, metrics in
+            GraphNode(
+                id: key,
+                degree: metrics.degree,
+                count: metrics.count,
+                bytes: metrics.hasBytes ? metrics.bytes : nil
+            )
+        }
+    }
+
+    private func validateSeries(_ series: AnalyticsSeries) -> [String] {
+        var issues: [String] = []
+        issues.append(contentsOf: validate(points: series.packetsPerBucket, label: "packetsPerBucket"))
+        issues.append(contentsOf: validate(points: series.bytesPerBucket, label: "bytesPerBucket"))
+        issues.append(contentsOf: validate(points: series.uniqueStationsPerBucket, label: "uniqueStationsPerBucket"))
+        return issues
+    }
+
+    private func validate(points: [AnalyticsSeriesPoint], label: String) -> [String] {
+        var issues: [String] = []
+        var seen: Set<Date> = []
+        var lastBucket: Date?
+
+        for point in points {
+            if let lastBucket, point.bucket < lastBucket {
+                issues.append("\(label).unsorted")
+            }
+            if !seen.insert(point.bucket).inserted {
+                issues.append("\(label).duplicateBucket")
+            }
+            lastBucket = point.bucket
+        }
+
+        return issues
+    }
+}

--- a/AXTerm/CallsignValidator.swift
+++ b/AXTerm/CallsignValidator.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum CallsignValidator {
-    private static let callsignPattern = "^[A-Z0-9]{1,6}(?:-[0-9]{1,2})?$"
+    nonisolated static let callsignPattern = "^[A-Z0-9]{1,6}(?:-[0-9]{1,2})?$"
 
     nonisolated static func normalize(_ value: String) -> String {
         value.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()

--- a/AXTerm/ContentView.swift
+++ b/AXTerm/ContentView.swift
@@ -31,6 +31,7 @@ struct ContentView: View {
     @State private var didLoadConsoleHistory = false
     @State private var didLoadRawHistory = false
     @State private var selectionMutationScheduler = SelectionMutationScheduler()
+    @StateObject private var analyticsViewModel = AnalyticsDashboardViewModel()
 
     init(client: PacketEngine, settings: AppSettingsStore, inspectionRouter: PacketInspectionRouter) {
         _client = StateObject(wrappedValue: client)
@@ -200,7 +201,7 @@ struct ContentView: View {
                     onClear: { client.clearRaw() }
                 )
             case .analytics:
-                AnalyticsDashboardView(packetEngine: client)
+                AnalyticsDashboardView(packetEngine: client, viewModel: analyticsViewModel)
             }
         }
     }

--- a/AXTerm/ContentView.swift
+++ b/AXTerm/ContentView.swift
@@ -11,6 +11,7 @@ enum NavigationItem: String, Hashable, CaseIterable {
     case packets = "Packets"
     case console = "Console"
     case raw = "Raw"
+    case analytics = "Analytics"
 }
 
 struct ContentView: View {
@@ -88,6 +89,8 @@ struct ContentView: View {
                 didLoadRawHistory = true
                 await Task.yield()
                 client.loadPersistedRaw()
+            case .analytics:
+                return
             }
         }
         .task(id: inspectionRouter.requestedPacketID) {
@@ -159,6 +162,7 @@ struct ContentView: View {
         case .packets: return "list.bullet.rectangle"
         case .console: return "terminal"
         case .raw: return "doc.text"
+        case .analytics: return "chart.bar"
         }
     }
 
@@ -195,6 +199,8 @@ struct ContentView: View {
                     showDaySeparators: settings.showRawDaySeparators,
                     onClear: { client.clearRaw() }
                 )
+            case .analytics:
+                AnalyticsDashboardView(packetEngine: client)
             }
         }
     }

--- a/AXTermTests/AnalyticsDashboardViewModelTests.swift
+++ b/AXTermTests/AnalyticsDashboardViewModelTests.swift
@@ -1,0 +1,144 @@
+//
+//  AnalyticsDashboardViewModelTests.swift
+//  AXTermTests
+//
+//  Created by AXTerm on 2026-02-21.
+//
+
+import XCTest
+@testable import AXTerm
+
+final class AnalyticsDashboardViewModelTests: XCTestCase {
+    private var calendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return calendar
+    }
+
+    func testChangingBucketTriggersSeriesRecompute() {
+        let date1 = makeDate(year: 2026, month: 2, day: 18, hour: 6, minute: 0, second: 0)
+        let date2 = makeDate(year: 2026, month: 2, day: 18, hour: 6, minute: 5, second: 0)
+        let packets = [
+            makePacket(timestamp: date1, from: "alpha", to: "beta"),
+            makePacket(timestamp: date2, from: "alpha", to: "beta")
+        ]
+
+        let viewModel = AnalyticsDashboardViewModel(
+            calendar: calendar,
+            bucket: .fiveMinutes,
+            includeViaDigipeaters: false,
+            minEdgeCount: 1,
+            packetDebounce: .zero,
+            packetScheduler: .main
+        )
+
+        viewModel.updatePackets(packets)
+        XCTAssertEqual(viewModel.series.packetsPerBucket.count, 2)
+
+        viewModel.bucket = .hour
+        XCTAssertEqual(viewModel.series.packetsPerBucket.count, 1)
+    }
+
+    func testTogglingIncludeViaTriggersEdgeRecompute() {
+        let timestamp = makeDate(year: 2026, month: 2, day: 18, hour: 6, minute: 0, second: 0)
+        let packets = [
+            makePacket(timestamp: timestamp, from: "alpha", to: "beta", via: ["dig1"])
+        ]
+
+        let viewModel = AnalyticsDashboardViewModel(
+            calendar: calendar,
+            bucket: .fiveMinutes,
+            includeViaDigipeaters: false,
+            minEdgeCount: 1,
+            packetDebounce: .zero,
+            packetScheduler: .main
+        )
+
+        viewModel.updatePackets(packets)
+        XCTAssertEqual(viewModel.edges.count, 1)
+
+        viewModel.includeViaDigipeaters = true
+        XCTAssertEqual(viewModel.edges.count, 2)
+    }
+
+    func testMinEdgeCountFiltersEdges() {
+        let timestamp = makeDate(year: 2026, month: 2, day: 18, hour: 6, minute: 0, second: 0)
+        let packets = [
+            makePacket(timestamp: timestamp, from: "alpha", to: "beta"),
+            makePacket(timestamp: timestamp, from: "alpha", to: "beta"),
+            makePacket(timestamp: timestamp, from: "beta", to: "gamma")
+        ]
+
+        let viewModel = AnalyticsDashboardViewModel(
+            calendar: calendar,
+            bucket: .fiveMinutes,
+            includeViaDigipeaters: false,
+            minEdgeCount: 1,
+            packetDebounce: .zero,
+            packetScheduler: .main
+        )
+
+        viewModel.updatePackets(packets)
+        XCTAssertEqual(viewModel.edges.count, 2)
+
+        viewModel.minEdgeCount = 2
+        XCTAssertEqual(viewModel.edges.count, 1)
+        XCTAssertEqual(viewModel.edges.first?.source, "alpha")
+    }
+
+    func testSelectionUpdatesDoNotCrash() {
+        let viewModel = AnalyticsDashboardViewModel(
+            calendar: calendar,
+            bucket: .fiveMinutes,
+            includeViaDigipeaters: false,
+            minEdgeCount: 1,
+            packetDebounce: .zero,
+            packetScheduler: .main
+        )
+
+        viewModel.selectNode("alpha")
+        XCTAssertEqual(viewModel.selectedNodeID, "alpha")
+
+        viewModel.updateHover(for: "alpha", isHovering: true)
+        XCTAssertEqual(viewModel.hoveredNodeID, "alpha")
+
+        viewModel.togglePinnedNode("alpha")
+        XCTAssertEqual(viewModel.pinnedNodeID, "alpha")
+
+        viewModel.updateHover(for: "alpha", isHovering: false)
+        XCTAssertNil(viewModel.hoveredNodeID)
+
+        viewModel.selectNode(nil)
+        XCTAssertNil(viewModel.selectedNodeID)
+    }
+}
+
+private extension AnalyticsDashboardViewModelTests {
+    func makeDate(year: Int, month: Int, day: Int, hour: Int, minute: Int, second: Int) -> Date {
+        calendar.date(from: DateComponents(
+            calendar: calendar,
+            timeZone: calendar.timeZone,
+            year: year,
+            month: month,
+            day: day,
+            hour: hour,
+            minute: minute,
+            second: second
+        )) ?? Date(timeIntervalSince1970: 0)
+    }
+
+    func makePacket(
+        timestamp: Date,
+        from: String? = nil,
+        to: String? = nil,
+        via: [String] = []
+    ) -> Packet {
+        Packet(
+            timestamp: timestamp,
+            from: from.map { AX25Address(call: $0) },
+            to: to.map { AX25Address(call: $0) },
+            via: via.map { AX25Address(call: $0) },
+            frameType: .ui
+        )
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide an incremental, debounced analytics pipeline and a minimal dashboard UI to inspect packet summaries, time series, and a basic network graph without a heavy UI refactor. 
- Surface recompute telemetry and breadcrumbs to aid observability (compute phases, layout, and filter interactions).
- Add unit tests for the pure view-model logic so UI tests can be kept out of scope.

### Description
- Add `AnalyticsDashboardViewModel.swift` implementing `AnalyticsDashboardViewModel` with debounced packet input, filter state (`bucket`, `includeViaDigipeaters`, `minEdgeCount`), incremental recompute methods (`recomputeSummary`, `recomputeSeries`, `recomputeEdges`, `recomputeLayout`), node/edge building, and Telemetry instrumentation (breadcrumbs: `analytics.dashboard.opened`, `analytics.filter.changed`, `analytics.graph.node.selected`; spans: `analytics.computeSummary`, `analytics.computeSeries`, `analytics.computeEdges`, `analytics.graph.layout`).
- Add `AnalyticsDashboardView.swift` with minimal SwiftUI sections: filters, summary cards, series previews (list-based fallback), and a `Canvas`-based network graph that renders nodes and edges and supports selection/hover/pin interactions.
- Wire the dashboard into the main UI by adding an `Analytics` navigation item and opening `AnalyticsDashboardView` from `ContentView`.
- Add `AnalyticsDashboardViewModelTests.swift` with unit tests that exercise the view model using fake packets (bucket change triggers series recompute, include-via toggles trigger edge recompute, `minEdgeCount` filters edges, selection/hover/pin updates do not crash). 

### Testing
- Added unit tests: `AnalyticsDashboardViewModelTests` covering recompute and selection behaviors; these tests are included in the test target but were not executed as part of this change. 
- No automated test run was performed in this rollout (no CI or `swift test` invocation was run locally). 
- Existing analytics/pipeline helpers (`AnalyticsEngine`, `GraphLayoutEngine`, telemetry backend) were reused by the view model and kept unchanged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b77ea66fc8330a1c0391e7c626073)