### PR TITLE
Refine analytics graph selection and station inspection

### DIFF
--- a/AXTerm/Analytics/GraphSelectionReducer.swift
+++ b/AXTerm/Analytics/GraphSelectionReducer.swift
@@ -1,0 +1,57 @@
+//
+//  GraphSelectionReducer.swift
+//  AXTerm
+//
+//  Created by AXTerm on 2026-02-23.
+//
+
+import Foundation
+
+struct GraphSelectionState: Equatable {
+    var selectedIDs: Set<String> = []
+    var primarySelectionID: String?
+
+    mutating func normalizePrimary() {
+        if let primarySelectionID, selectedIDs.contains(primarySelectionID) {
+            return
+        }
+        primarySelectionID = selectedIDs.sorted().first
+    }
+}
+
+enum GraphSelectionAction: Equatable {
+    case clickNode(id: String, isShift: Bool)
+    case clickBackground
+    case doubleClickNode(id: String, isShift: Bool)
+}
+
+enum GraphSelectionEffect: Equatable {
+    case none
+    case inspect(String)
+}
+
+enum GraphSelectionReducer {
+    static func reduce(state: inout GraphSelectionState, action: GraphSelectionAction) -> GraphSelectionEffect {
+        switch action {
+        case let .clickNode(id, isShift):
+            applyNodeClick(to: &state, id: id, isShift: isShift)
+            return .none
+        case .clickBackground:
+            state.selectedIDs.removeAll()
+            state.primarySelectionID = nil
+            return .none
+        case let .doubleClickNode(id, isShift):
+            applyNodeClick(to: &state, id: id, isShift: isShift)
+            return .inspect(id)
+        }
+    }
+
+    private static func applyNodeClick(to state: inout GraphSelectionState, id: String, isShift: Bool) {
+        if isShift {
+            state.selectedIDs.insert(id)
+        } else {
+            state.selectedIDs = [id]
+        }
+        state.primarySelectionID = id
+    }
+}

--- a/AXTerm/Analytics/StationInspectorView.swift
+++ b/AXTerm/Analytics/StationInspectorView.swift
@@ -1,0 +1,92 @@
+//
+//  StationInspectorView.swift
+//  AXTerm
+//
+//  Created by AXTerm on 2026-02-23.
+//
+
+import SwiftUI
+
+struct StationInspectorView: View {
+    @ObservedObject var viewModel: StationInspectorViewModel
+    var onClose: (() -> Void)?
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            header
+            statsSection
+            peersSection
+            Spacer(minLength: 0)
+        }
+        .padding(20)
+        .frame(minWidth: 420, idealWidth: 520, minHeight: 360, idealHeight: 420)
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button("Done") {
+                    dismiss()
+                    onClose?()
+                }
+            }
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(viewModel.stats.stationID)
+                .font(.title3.weight(.semibold))
+            Text("Inspect Station")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var statsSection: some View {
+        GroupBox("Packet counts") {
+            HStack(spacing: 16) {
+                metricCell(title: "From", value: viewModel.stats.fromCount)
+                metricCell(title: "To", value: viewModel.stats.toCount)
+                metricCell(title: "Via", value: viewModel.stats.viaCount)
+            }
+            .padding(.vertical, 4)
+        }
+    }
+
+    private var peersSection: some View {
+        GroupBox("Top peers") {
+            if viewModel.stats.topPeers.isEmpty {
+                Text("No peer traffic")
+                    .foregroundStyle(.secondary)
+                    .padding(.vertical, 6)
+            } else {
+                VStack(spacing: 8) {
+                    ForEach(viewModel.stats.topPeers) { peer in
+                        HStack {
+                            Text(peer.stationID)
+                            Spacer()
+                            Text("\(peer.count)")
+                                .foregroundStyle(.secondary)
+                        }
+                        .font(.caption)
+                    }
+                }
+                .padding(.vertical, 6)
+            }
+        }
+    }
+
+    private func metricCell(title: String, value: Int) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text("\(value)")
+                .font(.headline)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(10)
+        .background(Color.secondary.opacity(0.1))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+}

--- a/AXTerm/Analytics/StationInspectorViewModel.swift
+++ b/AXTerm/Analytics/StationInspectorViewModel.swift
@@ -5,6 +5,7 @@
 //  Created by AXTerm on 2026-02-23.
 //
 
+import Combine
 import Foundation
 
 final class StationInspectorViewModel: ObservableObject, Identifiable {

--- a/AXTerm/Analytics/StationInspectorViewModel.swift
+++ b/AXTerm/Analytics/StationInspectorViewModel.swift
@@ -1,0 +1,88 @@
+//
+//  StationInspectorViewModel.swift
+//  AXTerm
+//
+//  Created by AXTerm on 2026-02-23.
+//
+
+import Foundation
+
+final class StationInspectorViewModel: ObservableObject, Identifiable {
+    struct PeerStats: Identifiable, Equatable {
+        let stationID: String
+        let count: Int
+
+        var id: String { stationID }
+    }
+
+    struct StationStats: Equatable {
+        let stationID: String
+        let fromCount: Int
+        let toCount: Int
+        let viaCount: Int
+        let topPeers: [PeerStats]
+    }
+
+    let stationID: String
+
+    @Published private(set) var stats: StationStats
+
+    init(stationID: String, packets: [Packet], edges: [GraphEdge]) {
+        self.stationID = stationID
+        self.stats = StationInspectorViewModel.computeStats(
+            stationID: stationID,
+            packets: packets,
+            edges: edges
+        )
+    }
+
+    func update(packets: [Packet], edges: [GraphEdge]) {
+        stats = StationInspectorViewModel.computeStats(
+            stationID: stationID,
+            packets: packets,
+            edges: edges
+        )
+    }
+
+    private static func computeStats(
+        stationID: String,
+        packets: [Packet],
+        edges: [GraphEdge],
+        topPeerLimit: Int = 6
+    ) -> StationStats {
+        Telemetry.measure(name: "analytics.station.inspect.compute") {
+            let fromCount = packets.filter { $0.from?.call == stationID }.count
+            let toCount = packets.filter { $0.to?.call == stationID }.count
+            let viaCount = packets.filter { packet in
+                packet.via.contains(where: { $0.call == stationID })
+            }.count
+
+            var peerCounts: [String: Int] = [:]
+            for edge in edges {
+                if edge.source == stationID {
+                    peerCounts[edge.target, default: 0] += edge.count
+                } else if edge.target == stationID {
+                    peerCounts[edge.source, default: 0] += edge.count
+                }
+            }
+
+            let topPeers = peerCounts
+                .map { PeerStats(stationID: $0.key, count: $0.value) }
+                .sorted { lhs, rhs in
+                    if lhs.count != rhs.count {
+                        return lhs.count > rhs.count
+                    }
+                    return lhs.stationID.localizedCaseInsensitiveCompare(rhs.stationID) == .orderedAscending
+                }
+                .prefix(topPeerLimit)
+
+            return StationStats(
+                stationID: stationID,
+                fromCount: fromCount,
+                toCount: toCount,
+                viaCount: viaCount,
+                topPeers: Array(topPeers)
+            )
+        }
+    }
+}

--- a/AXTermTests/AnalyticsDashboardViewModelTests.swift
+++ b/AXTermTests/AnalyticsDashboardViewModelTests.swift
@@ -96,19 +96,20 @@ final class AnalyticsDashboardViewModelTests: XCTestCase {
             packetScheduler: .main
         )
 
-        viewModel.selectNode("alpha")
+        viewModel.handleNodeClick("alpha", isShift: false)
         XCTAssertEqual(viewModel.selectedNodeID, "alpha")
+        XCTAssertEqual(viewModel.selectedNodeIDs, ["alpha"])
 
         viewModel.updateHover(for: "alpha", isHovering: true)
         XCTAssertEqual(viewModel.hoveredNodeID, "alpha")
 
-        viewModel.togglePinnedNode("alpha")
-        XCTAssertEqual(viewModel.pinnedNodeID, "alpha")
+        viewModel.handleNodeDoubleClick("alpha", isShift: false)
+        XCTAssertNotNil(viewModel.stationInspector)
 
         viewModel.updateHover(for: "alpha", isHovering: false)
         XCTAssertNil(viewModel.hoveredNodeID)
 
-        viewModel.selectNode(nil)
+        viewModel.handleBackgroundClick()
         XCTAssertNil(viewModel.selectedNodeID)
     }
 }

--- a/AXTermTests/GraphSelectionReducerTests.swift
+++ b/AXTermTests/GraphSelectionReducerTests.swift
@@ -1,0 +1,47 @@
+//
+//  GraphSelectionReducerTests.swift
+//  AXTermTests
+//
+//  Created by AXTerm on 2026-02-23.
+//
+
+import XCTest
+@testable import AXTerm
+
+final class GraphSelectionReducerTests: XCTestCase {
+    func testClickSelects() {
+        var state = GraphSelectionState()
+
+        let effect = GraphSelectionReducer.reduce(
+            state: &state,
+            action: .clickNode(id: "alpha", isShift: false)
+        )
+
+        XCTAssertEqual(effect, .none)
+        XCTAssertEqual(state.selectedIDs, ["alpha"])
+        XCTAssertEqual(state.primarySelectionID, "alpha")
+    }
+
+    func testClickOutsideClears() {
+        var state = GraphSelectionState(selectedIDs: ["alpha", "beta"], primarySelectionID: "alpha")
+
+        let effect = GraphSelectionReducer.reduce(state: &state, action: .clickBackground)
+
+        XCTAssertEqual(effect, .none)
+        XCTAssertTrue(state.selectedIDs.isEmpty)
+        XCTAssertNil(state.primarySelectionID)
+    }
+
+    func testDoubleClickTriggersInspect() {
+        var state = GraphSelectionState()
+
+        let effect = GraphSelectionReducer.reduce(
+            state: &state,
+            action: .doubleClickNode(id: "alpha", isShift: false)
+        )
+
+        XCTAssertEqual(effect, .inspect("alpha"))
+        XCTAssertEqual(state.selectedIDs, ["alpha"])
+        XCTAssertEqual(state.primarySelectionID, "alpha")
+    }
+}

--- a/AXTermTests/StationInspectorViewModelTests.swift
+++ b/AXTermTests/StationInspectorViewModelTests.swift
@@ -1,0 +1,63 @@
+//
+//  StationInspectorViewModelTests.swift
+//  AXTermTests
+//
+//  Created by AXTerm on 2026-02-23.
+//
+
+import XCTest
+@testable import AXTerm
+
+final class StationInspectorViewModelTests: XCTestCase {
+    func testCountsCorrect() {
+        let timestamp = Date(timeIntervalSince1970: 0)
+        let packets = [
+            makePacket(timestamp: timestamp, from: "alpha", to: "beta"),
+            makePacket(timestamp: timestamp, from: "alpha", to: "delta"),
+            makePacket(timestamp: timestamp, from: "gamma", to: "alpha"),
+            makePacket(timestamp: timestamp, from: "beta", to: "gamma", via: ["alpha"]),
+            makePacket(timestamp: timestamp, from: "delta", to: "epsilon", via: ["alpha"])
+        ]
+        let edges: [GraphEdge] = []
+
+        let viewModel = StationInspectorViewModel(stationID: "alpha", packets: packets, edges: edges)
+
+        XCTAssertEqual(viewModel.stats.fromCount, 2)
+        XCTAssertEqual(viewModel.stats.toCount, 1)
+        XCTAssertEqual(viewModel.stats.viaCount, 2)
+    }
+
+    func testTopPeersDeterministic() {
+        let packets: [Packet] = []
+        let edges = [
+            GraphEdge(source: "alpha", target: "beta", count: 3, bytes: nil),
+            GraphEdge(source: "gamma", target: "alpha", count: 3, bytes: nil),
+            GraphEdge(source: "alpha", target: "delta", count: 1, bytes: nil),
+            GraphEdge(source: "epsilon", target: "alpha", count: 2, bytes: nil)
+        ]
+
+        let viewModel = StationInspectorViewModel(stationID: "alpha", packets: packets, edges: edges)
+
+        XCTAssertEqual(
+            viewModel.stats.topPeers.map { ($0.stationID, $0.count) },
+            [("beta", 3), ("gamma", 3), ("epsilon", 2), ("delta", 1)]
+        )
+    }
+}
+
+private extension StationInspectorViewModelTests {
+    func makePacket(
+        timestamp: Date,
+        from: String,
+        to: String,
+        via: [String] = []
+    ) -> Packet {
+        Packet(
+            timestamp: timestamp,
+            from: AX25Address(call: from),
+            to: AX25Address(call: to),
+            via: via.map { AX25Address(call: $0) },
+            frameType: .ui
+        )
+    }
+}


### PR DESCRIPTION
### Motivation
- Make the network graph feel more native by supporting single-click selection, shift-click multi-selection, double-click inspection, keyboard clear, and selection → packet-table sync. 
- Provide a small inspector VM to compute deterministic station stats (from/to/via counts and top peers) and add Sentry-style telemetry around interactions and compute spans.

### Description
- Added a pure selection reducer `GraphSelectionReducer` and `GraphSelectionState` to manage click/shift-click/double-click semantics and return effects like `inspect` (`AXTerm/Analytics/GraphSelectionReducer.swift`).
- Implemented `StationInspectorViewModel` that computes `from`/`to`/`via` counts and deterministic top peers with a telemetry span `analytics.station.inspect.compute` (`AXTerm/Analytics/StationInspectorViewModel.swift`).
- Created `StationInspectorView` and wired it as a `.sheet` from the analytics dashboard so double-clicking a node opens the inspector (`AXTerm/Analytics/StationInspectorView.swift`, `AXTerm/Analytics/AnalyticsDashboardView.swift`).
- Reworked `AnalyticsDashboardViewModel` to use the reducer for selection, expose `selectedNodeIDs` + primary `selectedNodeID`, reconcile selection after layout, capture invariant failures for missing node ids, and handle selection effects to open the inspector while emitting breadcrumbs and span instrumentation (`AXTerm/Analytics/AnalyticsDashboardViewModel.swift`).
- Updated `AnalyticsGraphView` interactions to support shift-click multi-select, double-click inspect gestures, background click to clear selection, keyboard Esc handling, and primary/secondary selection visuals (`AXTerm/Analytics/AnalyticsDashboardView.swift`).
- Removed the previous pinned-node toggle in favor of the new selection/inspect workflow and synced `selectedNodeID` to `PacketEngine.selectedStationCall` so selection filters the packet table.
- Added/updated unit tests for reducer and inspector logic and adjusted `AnalyticsDashboardViewModelTests` to exercise the new selection API (`AXTermTests/GraphSelectionReducerTests.swift`, `AXTermTests/StationInspectorViewModelTests.swift`, `AXTermTests/AnalyticsDashboardViewModelTests.swift`).

### Testing
- Added unit tests: `GraphSelectionReducerTests` to validate click/select/double-click effects, and `StationInspectorViewModelTests` to validate counts and deterministic top-peer ordering, and updated `AnalyticsDashboardViewModelTests` selection assertions; these are present under `AXTermTests` but were not executed as part of this change.
- No automated test runs were performed as part of this PR, so pass/fail status is not available for this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b811a1e7083309e93c60f0388fd6d)