### PR TITLE
Fix All Packets live refresh and sorting

### DIFF
--- a/AXTerm/PacketTableView.swift
+++ b/AXTerm/PacketTableView.swift
@@ -13,23 +13,84 @@ struct PacketTableView: View {
     let onInspectSelection: () -> Void
     let onCopyInfo: (Packet) -> Void
     let onCopyRawHex: (Packet) -> Void
+    @State private var isAtTop = true
+    @State private var followNewest = true
+    @State private var pendingNewPackets = 0
+    @State private var lastTopPacketID: Packet.ID?
+    @State private var scrollToTopToken = 0
 
     var body: some View {
-        PacketNSTableView(
-            packets: packets,
-            selection: $selection,
-            onInspectSelection: onInspectSelection,
-            onCopyInfo: onCopyInfo,
-            onCopyRawHex: onCopyRawHex
-        )
-        .focusable(true)
-        .background(
-            Button(action: onInspectSelection) {
-                EmptyView()
+        ZStack(alignment: .topTrailing) {
+            PacketNSTableView(
+                packets: packets,
+                selection: $selection,
+                isAtTop: $isAtTop,
+                followNewest: $followNewest,
+                scrollToTopToken: scrollToTopToken,
+                onInspectSelection: onInspectSelection,
+                onCopyInfo: onCopyInfo,
+                onCopyRawHex: onCopyRawHex
+            )
+            .focusable(true)
+            .background(
+                Button(action: onInspectSelection) {
+                    EmptyView()
+                }
+                .keyboardShortcut(.defaultAction)
+                .hidden()
+                .allowsHitTesting(false)
+            )
+
+            if pendingNewPackets > 0 {
+                Button {
+                    followNewest = true
+                    pendingNewPackets = 0
+                    scrollToTopToken += 1
+                } label: {
+                    Label("New packets (\(pendingNewPackets))", systemImage: "arrow.up.circle.fill")
+                        .labelStyle(.titleAndIcon)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+                .padding([.top, .trailing], 12)
             }
-            .keyboardShortcut(.defaultAction)
-            .hidden()
-            .allowsHitTesting(false)
-        )
+        }
+        .onChange(of: packets) { _, newValue in
+            guard !newValue.isEmpty else {
+                pendingNewPackets = 0
+                lastTopPacketID = nil
+                return
+            }
+
+            if isAtTop || followNewest {
+                pendingNewPackets = 0
+                lastTopPacketID = newValue.first?.id
+            } else {
+                let nextCount = countNewPackets(previousTopID: lastTopPacketID, packets: newValue)
+                if nextCount > 0 {
+                    pendingNewPackets += nextCount
+                }
+                lastTopPacketID = newValue.first?.id
+            }
+        }
+        .onChange(of: isAtTop) { _, newValue in
+            if newValue {
+                pendingNewPackets = 0
+                followNewest = true
+                lastTopPacketID = packets.first?.id
+            } else {
+                followNewest = false
+            }
+        }
+    }
+
+    private func countNewPackets(previousTopID: Packet.ID?, packets: [Packet]) -> Int {
+        guard let previousTopID else {
+            return packets.count
+        }
+        if let index = packets.firstIndex(where: { $0.id == previousTopID }) {
+            return index
+        }
+        return packets.count
     }
 }

--- a/AXTermTests/PacketOrderingTests.swift
+++ b/AXTermTests/PacketOrderingTests.swift
@@ -1,0 +1,64 @@
+//
+//  PacketOrderingTests.swift
+//  AXTermTests
+//
+//  Created by AXTerm on 2026-02-06.
+//
+
+import XCTest
+@testable import AXTerm
+
+@MainActor
+final class PacketOrderingTests: XCTestCase {
+    func testIncomingPacketsStaySortedNewestFirst() {
+        let settings = makeSettings(persistHistory: false)
+        let client = PacketEngine(maxPackets: 10, settings: settings)
+        let base = Date()
+        let packetA = Packet(id: UUID(), timestamp: base.addingTimeInterval(-10), from: AX25Address(call: "A"))
+        let packetB = Packet(id: UUID(), timestamp: base.addingTimeInterval(-5), from: AX25Address(call: "B"))
+        let packetC = Packet(id: UUID(), timestamp: base.addingTimeInterval(-7), from: AX25Address(call: "C"))
+
+        client.handleIncomingPacket(packetA)
+        client.handleIncomingPacket(packetB)
+        client.handleIncomingPacket(packetC)
+
+        XCTAssertEqual(client.packets.map(\.id), [packetB.id, packetC.id, packetA.id])
+    }
+
+    func testIncomingPacketsUseIdTiebreaker() {
+        let settings = makeSettings(persistHistory: false)
+        let client = PacketEngine(maxPackets: 10, settings: settings)
+        let timestamp = Date()
+        let lowerID = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+        let higherID = UUID(uuidString: "00000000-0000-0000-0000-000000000002")!
+        let packetA = Packet(id: lowerID, timestamp: timestamp, from: AX25Address(call: "A"))
+        let packetB = Packet(id: higherID, timestamp: timestamp, from: AX25Address(call: "B"))
+
+        client.handleIncomingPacket(packetA)
+        client.handleIncomingPacket(packetB)
+
+        XCTAssertEqual(client.packets.map(\.id), [higherID, lowerID])
+    }
+
+    func testSelectionRemainsAfterInsert() {
+        let settings = makeSettings(persistHistory: false)
+        let client = PacketEngine(maxPackets: 10, settings: settings)
+        let selectedID = UUID()
+        let selectedPacket = Packet(id: selectedID, timestamp: Date(), from: AX25Address(call: "A"))
+
+        client.handleIncomingPacket(selectedPacket)
+        let selection: Set<Packet.ID> = [selectedID]
+
+        client.handleIncomingPacket(Packet(id: UUID(), timestamp: Date().addingTimeInterval(1), from: AX25Address(call: "B")))
+
+        let updatedSelection = PacketSelectionResolver.filteredSelection(selection, for: client.packets)
+        XCTAssertEqual(updatedSelection, selection)
+    }
+
+    private func makeSettings(persistHistory: Bool) -> AppSettingsStore {
+        let suiteName = "AXTermTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName) ?? .standard
+        defaults.set(persistHistory, forKey: AppSettingsStore.persistKey)
+        return AppSettingsStore(defaults: defaults)
+    }
+}


### PR DESCRIPTION
### Motivation
- The All Packets table wasn't updating live because new packets were being appended in a way that didn't match the table's expectations, causing stale ordering and selection/scroll jitter. 
- Sorting needed to be deterministic (newest-first using real `timestamp` with a stable id tiebreaker) and UI should preserve selection and scroll unless the user is following the tail. 
- Add Sentry breadcrumbs around insert/fetch lifecycle to help diagnose future issues. 

### Description
- Keep the in-memory packet list sorted and insert new packets at the correct position using a binary `insertionIndex` and `shouldPrecede` comparator based on `timestamp` then `id`, and use it when handling incoming and loaded packets (`AXTerm/PacketEngine.swift`).
- Add Sentry breadcrumbs for packet insert receipt and commit inside `handleIncomingPacket` / `persistPacket` (`AXTerm/PacketEngine.swift`).
- Track scroll/follow state and present a non-intrusive "New packets (N)" indicator when the user is not at the top, and wire a follow-newest token to force-scroll when the user chooses to follow (`AXTerm/PacketTableView.swift`).
- Make the NSTableView coordinator aware of scroll state, preserve an anchor row for stable scroll position on incremental updates, and perform controlled scroll-to-top when following; also preserve and reapply selection using stable IDs (`AXTerm/PacketNSTableView.swift`).
- Ensure persisted history load is sorted newest-first on apply (`AXTerm/PacketEngine.swift`).
- Add unit tests that cover ordering and selection preservation (`AXTermTests/PacketOrderingTests.swift`).

Files changed: `AXTerm/PacketEngine.swift`, `AXTerm/PacketNSTableView.swift`, `AXTerm/PacketTableView.swift`, and added `AXTermTests/PacketOrderingTests.swift`.

### Testing
- Added unit tests: `PacketOrderingTests.testIncomingPacketsStaySortedNewestFirst`, `PacketOrderingTests.testIncomingPacketsUseIdTiebreaker`, and `PacketOrderingTests.testSelectionRemainsAfterInsert` (new file `AXTermTests/PacketOrderingTests.swift`).
- Attempted to run the test suite with `xcodebuild -project AXTerm.xcodeproj -scheme AXTermTests -destination 'platform=macOS' test` but `xcodebuild` is not available in this environment so tests were not executed here.
- Recommend running the test scheme in CI or a macOS dev machine to validate all tests and confirm UI behaviour end-to-end (selection, double-click inspector, follow-tail and new-packets indicator).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b8546c3ec8330901a2763cec28740)