### PR TITLE
Populate and keep Stations sidebar live on launch and packet inserts

### DIFF
--- a/AXTermTests/StationsSidebarTests.swift
+++ b/AXTermTests/StationsSidebarTests.swift
@@ -1,0 +1,104 @@
+//
+//  StationsSidebarTests.swift
+//  AXTermTests
+//
+//  Created by AXTerm on 2026-02-08.
+//
+
+import XCTest
+@testable import AXTerm
+
+@MainActor
+final class StationsSidebarTests: XCTestCase {
+    func testStationsSeedFromPersistedPacketsOnInit() async {
+        let settings = makeSettings(persistHistory: true)
+        let store = MockPacketStore()
+        let endpoint = KISSEndpoint(host: "localhost", port: 8001)
+
+        let earlier = Date(timeIntervalSince1970: 1_700_000_000)
+        let later = Date(timeIntervalSince1970: 1_700_000_100)
+
+        let firstPacket = Packet(
+            timestamp: earlier,
+            from: AX25Address(call: "ALPHA"),
+            to: AX25Address(call: "DEST"),
+            frameType: .ui,
+            control: 0x03,
+            info: Data([0x41]),
+            rawAx25: Data([0x01]),
+            kissEndpoint: endpoint
+        )
+
+        let secondPacket = Packet(
+            timestamp: later,
+            from: AX25Address(call: "BRAVO"),
+            to: AX25Address(call: "DEST"),
+            frameType: .ui,
+            control: 0x03,
+            info: Data([0x42]),
+            rawAx25: Data([0x02]),
+            kissEndpoint: endpoint
+        )
+
+        store.loadResult = [
+            try! PacketRecord(packet: firstPacket, endpoint: endpoint),
+            try! PacketRecord(packet: secondPacket, endpoint: endpoint)
+        ]
+
+        let client = PacketEngine(
+            maxPackets: 10,
+            settings: settings,
+            packetStore: store
+        )
+
+        await waitForStations(client, minimumCount: 2)
+
+        XCTAssertEqual(client.stations.count, 2)
+        XCTAssertEqual(client.stations.first?.call, "BRAVO")
+        XCTAssertEqual(client.stations.last?.call, "ALPHA")
+    }
+
+    func testStationsUpdateAndPreserveSelectionOnInsert() async {
+        let settings = makeSettings(persistHistory: false)
+        let client = PacketEngine(settings: settings)
+
+        let base = Date()
+        let firstPacket = Packet(timestamp: base, from: AX25Address(call: "ALPHA"))
+        client.handleIncomingPacket(firstPacket)
+
+        await waitForStations(client, minimumCount: 1)
+        client.selectedStationCall = "ALPHA"
+
+        let secondPacket = Packet(timestamp: base.addingTimeInterval(10), from: AX25Address(call: "BRAVO"))
+        client.handleIncomingPacket(secondPacket)
+
+        await waitForStations(client, minimumCount: 2)
+        XCTAssertEqual(client.stations.first?.call, "BRAVO")
+        XCTAssertEqual(client.stations.last?.call, "ALPHA")
+        XCTAssertEqual(client.selectedStationCall, "ALPHA")
+
+        let thirdPacket = Packet(timestamp: base.addingTimeInterval(20), from: AX25Address(call: "ALPHA"))
+        client.handleIncomingPacket(thirdPacket)
+
+        await waitForStations(client, minimumCount: 2)
+        XCTAssertEqual(client.stations.first?.call, "ALPHA")
+        XCTAssertEqual(client.stations.first?.heardCount, 2)
+        XCTAssertEqual(client.selectedStationCall, "ALPHA")
+    }
+
+    private func makeSettings(persistHistory: Bool) -> AppSettingsStore {
+        let suiteName = "AXTermTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName) ?? .standard
+        defaults.set(persistHistory, forKey: AppSettingsStore.persistKey)
+        return AppSettingsStore(defaults: defaults)
+    }
+
+    private func waitForStations(_ client: PacketEngine, minimumCount: Int) async {
+        for _ in 0..<20 {
+            if client.stations.count >= minimumCount {
+                return
+            }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- The Stations sidebar could appear empty or stale on app launch and would not update immediately as packets arrived, because station population was performed lazily and not driven by the same reactive packet-insert signal as the packet list.
- The intent is to seed Stations at startup/reconnect, update incrementally on packet inserts (no polling), preserve selection, and avoid expensive full recomputations.

### Description
- Hooked Stations updates to packet insert events by adding a `PassthroughSubject<Packet, Never>` (`packetInsertSubject`) to `PacketEngine` and subscribing to it in `configureStationSubscription()` so station tracking is driven reactively when packets arrive.
- Seeded stations at app startup and on `connect` by calling a new `loadPersistedPackets(reason:)` path from `init` and `connect`, which will load persisted packets and call `applyLoadedPackets(...)` to populate `packets` and `stations` immediately (with Sentry breadcrumbs `stations.initial_load.start` / `stations.initial_load.end`).
- On incoming packets `handleIncomingPacket(_:)` now sends the packet to `packetInsertSubject` (instead of directly updating stations) so both initial load and live inserts use the same update path; added Sentry breadcrumbs `stations.update.on_packet_insert` for visibility.
- Reworked `StationTracker` by adding `rebuild(from:)` that efficiently aggregates per-call metrics from an array of packets and a `heardCount(for:)` lookup to allow incremental updates without full recompute; improved `sortStations()` to sort by `lastHeard` (DESC) then `call` (case-insensitive ASC) for stable ordering.
- Kept selection semantics intact by not clearing `selectedStationCall` as part of normal station updates (only `clearStations()` still clears selection).
- Files changed: `AXTerm/PacketEngine.swift` (added `packetInsertSubject`, startup/connect seeding, subscription wiring, breadcrumbs), `AXTerm/StationTracker.swift` (added `rebuild(from:)`, `heardCount(for:)`, and improved sorting), and tests added in `AXTermTests/StationsSidebarTests.swift`.

### Testing
- Added unit tests in `AXTermTests/StationsSidebarTests.swift` with `testStationsSeedFromPersistedPacketsOnInit` and `testStationsUpdateAndPreserveSelectionOnInsert` to validate initial seeding, live updates, ordering, and selection stability.
- Attempted to run the test suite via `xcodebuild -project AXTerm.xcodeproj -scheme AXTerm -destination 'platform=macOS' test`, but `xcodebuild` was not available in this environment and the run failed. The tests were added and committed but could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b8befb6e08330be743515645d34c3)