### PR TITLE
Fix packet table feedback-loops and stop idle Analytics work

### DIFF
--- a/AXTerm/Analytics/AnalyticsStyle.swift
+++ b/AXTerm/Analytics/AnalyticsStyle.swift
@@ -57,9 +57,9 @@ enum AnalyticsStyle {
         static let springStrength: Double = 0.12
         static let springLength: Double = 0.18
         static let nodeRadiusRange: ClosedRange<CGFloat> = 4...12
-        static let nodeHitRadius: CGFloat = 12
-        static let edgeThicknessRange: ClosedRange<CGFloat> = 0.4...2.0
-        static let edgeAlphaRange: ClosedRange<Double> = 0.08...0.5
+        static let nodeHitRadius: CGFloat = 16
+        static let edgeThicknessRange: ClosedRange<CGFloat> = 0.8...2.6
+        static let edgeAlphaRange: ClosedRange<Double> = 0.2...0.8
         static let selectionGlowWidth: CGFloat = 4
         static let zoomRange: ClosedRange<CGFloat> = 0.6...2.6
         static let focusScale: CGFloat = 1.4
@@ -82,7 +82,7 @@ enum AnalyticsStyle {
         }
 
         static let neutralFill = Color(nsColor: .secondaryLabelColor).opacity(0.12)
-        static let graphEdge = Color(nsColor: .secondaryLabelColor).opacity(0.35)
+        static let graphEdge = Color(nsColor: .secondaryLabelColor).opacity(0.55)
         static let graphNode = Color(nsColor: .labelColor)
         static let graphNodeMuted = Color(nsColor: .secondaryLabelColor)
     }

--- a/AXTerm/Analytics/TimeBucket.swift
+++ b/AXTerm/Analytics/TimeBucket.swift
@@ -17,15 +17,30 @@ enum TimeBucket: String, CaseIterable, Hashable, Sendable {
     var displayName: String {
         switch self {
         case .minute:
-            return "minute"
+            return "1 min"
         case .fiveMinutes:
-            return "fiveMinutes"
+            return "5 min"
         case .fifteenMinutes:
-            return "fifteenMinutes"
+            return "15 min"
         case .hour:
-            return "hour"
+            return "1 hour"
         case .day:
-            return "day"
+            return "1 day"
+        }
+    }
+
+    var axisStride: (component: Calendar.Component, count: Int) {
+        switch self {
+        case .minute:
+            return (.minute, 1)
+        case .fiveMinutes:
+            return (.minute, 5)
+        case .fifteenMinutes:
+            return (.minute, 15)
+        case .hour:
+            return (.hour, 1)
+        case .day:
+            return (.day, 1)
         }
     }
 

--- a/AXTerm/AutoScrollDecision.swift
+++ b/AXTerm/AutoScrollDecision.swift
@@ -13,6 +13,6 @@ enum AutoScrollDecision {
         followNewest: Bool,
         didRequestScrollToTop: Bool
     ) -> Bool {
-        didRequestScrollToTop || followNewest || isUserAtTop
+        didRequestScrollToTop || (followNewest && isUserAtTop)
     }
 }

--- a/AXTerm/ConsoleView.swift
+++ b/AXTerm/ConsoleView.swift
@@ -90,13 +90,11 @@ struct ConsoleView: View {
                     isUserNearBottom = distanceFromBottom <= 24
                 }
                 .onChange(of: lines.count) { _, _ in
-                    guard autoScroll, isUserNearBottom, let lastLine = lines.last else { return }
+                    guard autoScroll, isUserNearBottom else { return }
                     Task { @MainActor in
                         // Avoid triggering scroll/layout during the same update transaction.
                         await Task.yield()
-                        withAnimation(.easeOut(duration: 0.1)) {
-                            proxy.scrollTo(lastLine.id, anchor: .bottom)
-                        }
+                        proxy.scrollTo("bottom", anchor: .bottom)
                     }
                 }
             }

--- a/AXTerm/PerformanceNotes.md
+++ b/AXTerm/PerformanceNotes.md
@@ -1,0 +1,14 @@
+# Performance Findings (March 2026)
+
+## Root cause
+- Packet table updates were writing SwiftUI bindings during `NSViewRepresentable` updates and scroll callbacks. That synchronous feedback loop (scroll -> binding write -> updateNSView -> scroll) could peg CPU when switching tabs, especially after Analytics kicked off work. The table also rebuilt row models + column sizing on every packet, increasing update pressure.
+- Analytics graph layout tasks and aggregation work could remain active even after the Analytics view disappeared, keeping background work alive and amplifying main-thread updates when returning to Packets.
+
+## Fix summary
+- Packet table updates are now coalesced and guarded against re-entrant scroll/binding updates. Scroll state bindings publish on the next run loop (throttled), and programmatic scrolls ignore scroll callbacks to avoid feedback loops.
+- Table row updates only insert/remove when packets append at the top or truncate at the bottom, falling back to reloads only when needed. Column sizing is throttled.
+- Analytics view lifecycle now activates/deactivates aggregation/graph work and cancels layout tasks on disappear to prevent background loops.
+
+## Validation notes
+- Use Instruments + Points of Interest (or debug logs) to verify no hot loop in `PacketNSTableView` after switching Analytics → Packets.
+- Confirm Analytics layout ticks stop after leaving the Analytics screen.


### PR DESCRIPTION
### Motivation
- Resolve a SwiftUI ↔ AppKit feedback loop that could peg CPU when switching between Analytics and Packets by preventing coordinators from writing bindings synchronously during view/layout/scroll updates. 
- Reduce scroll jank and auto-scroll churn in the Packets and Console views so user scrolling is not fought by programmatic scrolls. 
- Stop Analytics background layout/aggregation work from continuing after the dashboard is hidden to stabilize CPU usage and improve graph UX.

### Description
- Packet table updates are coalesced and throttled: `PacketNSTableView.Coordinator` now exposes `enqueueUpdate(...)` and uses a `CoalescingScheduler` to batch updates, with an `isProgrammaticUpdate` reentrancy guard to avoid writing `@Binding` state during view updates. 
- Scroll-state publishing is debounced and moved off critical update paths by scheduling binding writes via `DispatchQueue.main.async`/`DispatchWorkItem` (throttled ~100ms) and only publishing when the value actually changes using `scheduleScrollStateUpdate`. 
- Row updates are incremental when possible: the coordinator computes insert/remove deltas (top-insert / bottom-truncate) and only falls back to full `reloadData()` when necessary, and column sizing is throttled via a `CoalescingScheduler`. 
- Auto-scroll logic tightened: `AutoScrollDecision.shouldAutoScroll` now requires being both `followNewest` and `isUserAtTop` (or an explicit scroll-to-top request), and programmatic scrolls are gated to avoid fighting user-initiated scrolls. 
- Console auto-scroll simplified to jump to the bottom anchor (no animated per-row scroll), reducing layout churn (`ConsoleView` now `scrollTo(

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ba8feb6b88330b2c7cf5e1618af4d)