### PR TITLE
Follow-up: fix serial close/open races for Feature/usb serial

### DIFF
--- a/AXTerm/Transmission/KISSLinkSerial.swift
+++ b/AXTerm/Transmission/KISSLinkSerial.swift
@@ -520,22 +520,23 @@ final class KISSLinkSerial: KISSLink, @unchecked Sendable {
         }
 
         // CLEANUP when timer is cancelled
+        let timerFD = fd
+        let timerIsBluetoothSerial = isBluetoothSerial
+        let timerOriginalTermios = originalTermios
+
         pollTimer.setCancelHandler { [weak self] in
             guard let self else { return }
-            self.lock.lock()
-            let currentFd = self.fileDescriptor
-            let isBT = self.isBluetoothSerial
-            self.lock.unlock()
-
-            if currentFd >= 0 {
+            if timerFD >= 0 {
                 // Restore original termios before closing (skip for BT serial)
-                if !isBT {
-                    var origTermios = self.originalTermios
-                    tcsetattr(currentFd, TCSANOW, &origTermios)
+                if !timerIsBluetoothSerial {
+                    var origTermios = timerOriginalTermios
+                    tcsetattr(timerFD, TCSANOW, &origTermios)
                 }
-                Darwin.close(currentFd)
+                Darwin.close(timerFD)
                 self.lock.lock()
-                self.fileDescriptor = -1
+                if self.fileDescriptor == timerFD {
+                    self.fileDescriptor = -1
+                }
                 self.lock.unlock()
             }
 
@@ -792,6 +793,7 @@ final class KISSLinkSerial: KISSLink, @unchecked Sendable {
         let timer = readPollTimer
         readPollTimer = nil
         let fd = fileDescriptor
+        isConnecting = false
         lock.unlock()
 
         // Always release the static guard synchronously so that an immediate
@@ -898,4 +900,3 @@ final class KISSLinkSerial: KISSLink, @unchecked Sendable {
         }
     }
 }
-


### PR DESCRIPTION
### Motivation
- Fix two high-priority race conditions in `AXTerm/Transmission/KISSLinkSerial.swift` that could close the wrong file descriptor during timer cancellation and allow an in-flight `open()` to be resurrected after `close()`.

### Description
- Capture the timer-owned FD and termios state at timer creation and use those captured values inside the poll timer cancel handler so it closes the original FD instead of reading `self.fileDescriptor` at cancel time (file: `AXTerm/Transmission/KISSLinkSerial.swift`).
- Only clear `self.fileDescriptor` in the cancel handler when it still matches the timer-owned FD to avoid clobbering a newly opened descriptor.
- Clear `isConnecting` inside `closeInternal(reason:)` while holding the lock so a later `finishOpen` treats a late open completion as canceled instead of resurrecting the connection.

### Testing
- Attempted to run unit tests with `xcodebuild -project AXTerm.xcodeproj -scheme AXTerm -destination 'platform=macOS' -only-testing:AXTermTests test`, but `xcodebuild` is not available in this environment, so automated tests could not be executed here (failed: `command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994bce180c08330947bfedb3807066d)